### PR TITLE
feat: refactor playground component to hoist application logic out

### DIFF
--- a/apps/playground/app/(main)/[lang]/anza/[lessonId]/anza-client.tsx
+++ b/apps/playground/app/(main)/[lang]/anza/[lessonId]/anza-client.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-// import { useContext } from "react";
 import { useNuru } from "@nuru/wasm/react";
-// import { AuthContext } from "@/components/providers/auth-provider";
 import { Playground } from "@/components/playground/playground";
 import { Executor } from "@/lib/executor";
 import { useTheme } from "next-themes";
-import { Lesson, Language } from "@/types/playground";
+import { Lesson, Language, PlaygroundLabels } from "@/types/playground";
 import { Dictionary } from "@/app/(main)/[lang]/dictionaries";
-import { Suspense } from "react";
+import { Suspense, useState, useEffect, useCallback, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import confetti from "canvas-confetti";
+import { nuruLanguage } from "@/lib/nuru-syntax";
 
 interface AnzaClientProps {
 	lesson: Lesson;
@@ -19,19 +20,177 @@ interface AnzaClientProps {
 
 export function AnzaClient({ lesson, nextLessonId, lang, dict }: AnzaClientProps) {
 	const { theme, forcedTheme } = useTheme();
-	// const { isAuthenticated, claims } = useContext(AuthContext);
+	const router = useRouter();
+	const searchParams = useSearchParams();
+	const [currentStepIndex, setCurrentStepIndex] = useState(0);
 
-	const nuruExecutor = new Executor("nuru", useNuru);
+	// Initial step from URL
+	useEffect(() => {
+		const stepId = searchParams.get("step");
+		if (stepId) {
+			const index = lesson.steps.findIndex((s) => s.id === stepId);
+			if (index !== -1) {
+				setCurrentStepIndex(index);
+			}
+		}
+	}, [searchParams, lesson.steps]);
+
+	const currentStep = lesson.steps[currentStepIndex];
+
+	const [code, setCode] = useState(currentStep.initialCode);
+	const [output, setOutput] = useState("");
+	const [isRunning, setIsRunning] = useState(false);
+	const [completedStepIndices, setCompletedStepIndices] = useState<Set<number>>(new Set());
+
+	// Sync code when step changes
+	useEffect(() => {
+		setCode(currentStep.initialCode);
+		setOutput("");
+	}, [currentStepIndex, lesson.id, currentStep.initialCode]);
+
+	// Reset progress when lesson changes
+	useEffect(() => {
+		setCompletedStepIndices(new Set());
+	}, [lesson.id]);
+
+	const executor = new Executor("nuru", useNuru);
+
+	// Call useNuru at top level
+	// const nuru = useNuru(executor.outputHandler);
+
+	// Sync nuru instance with executor
+	// useEffect(() => {
+	// 	if (nuru) {
+	// 		executor.setInstance(nuru);
+	// 	}
+	// }, [nuru, executor]);
+
+	useEffect(() => {
+		executor.onOutput((text, isError) => {
+			setOutput((prev) => (prev ? prev + `\n${text}` : text));
+		});
+	}, [executor]);
+
+	const checkSolution = useCallback((currentCode: string) => {
+		if (!currentStep.solution) return false;
+		
+		// Simple normalization: remove whitespace and comments
+		const normalize = (s: string) => s.replace(/\/\/.*$/gm, "").replace(/\s/g, "");
+		const isCorrect = normalize(currentCode) === normalize(currentStep.solution);
+		
+		if (isCorrect) {
+			setCompletedStepIndices(prev => new Set(prev).add(currentStepIndex));
+			confetti({
+				particleCount: 100,
+				spread: 70,
+				origin: { y: 0.6 },
+				colors: ["#22c55e", "#10b981", "#3b82f6"]
+			});
+		}
+		return isCorrect;
+	}, [currentStep.solution, currentStepIndex]);
+
+	const handleRun = async () => {
+		setIsRunning(true);
+		if (executor.onBeforeRun) {
+			executor.onBeforeRun();
+		}
+		setOutput("");
+		try {
+			await executor.run(code);
+			checkSolution(code);
+		} catch (error) {
+			setOutput(`${dict.playground.error}${error}`);
+		} finally {
+			setIsRunning(false);
+		}
+	};
+
+	const handleSubmit = async () => {
+		setOutput(dict.playground.testing);
+		try {
+			const result = await executor.submit(code);
+			setOutput(result);
+		} catch (error) {
+			setOutput(`${dict.playground.error}${error}`);
+		}
+	};
+
+	const handleShowSolution = () => {
+		if (currentStep.solution) {
+			setCode(currentStep.solution);
+		} else if (executor.getSolution) {
+			setCode(executor.getSolution());
+		}
+	};
+
+	const handleShowHint = () => {
+		const hintMessage = dict.playground.hint;
+		setOutput(prev => prev ? `${prev}\n\n${hintMessage}` : hintMessage);
+	};
+
+	const handleReset = () => {
+		setCode(currentStep.initialCode);
+		setOutput("");
+	};
+
+	const handleNextLesson = () => {
+		if (nextLessonId) {
+			router.push(`/${lang}/anza/${nextLessonId}`);
+		} else {
+			router.push(`/${lang}/anza`);
+		}
+	};
+
+	const labels: PlaygroundLabels = {
+		run: "RUN",
+		testing: dict.playground.testing,
+		error: dict.playground.error,
+		hint: dict.playground.hint,
+		reset: dict.codePanel.reset,
+		showSolution: dict.codePanel.showSolution,
+		nextLesson: dict.lessonPanel.nextLesson,
+		backToLessons: dict.lessonPanel.lessons,
+		completed: dict.lessonPanel.completed,
+		step: dict.lessonPanel.step,
+		of: "OF",
+		terminal: "Terminal",
+		outputPlaceholder: dict.outputPanel.placeholder,
+		lessons: dict.lessonPanel.lessons,
+		incomplete: dict.lessonPanel.incomplete,
+		back: dict.lessonPanel.back,
+		next: dict.lessonPanel.next,
+		finish: dict.lessonPanel.finish,
+		yourTask: dict.lessonPanel.yourTask,
+	};
+
+	const extensions = useMemo(() => [nuruLanguage], []);
 
 	return (
 		<Suspense fallback={<div className="flex-1 bg-background animate-pulse" />}>
 			<Playground
 				theme={(forcedTheme || theme) as "light" | "dark"}
 				lesson={lesson}
-				executor={nuruExecutor}
-				nextLessonId={nextLessonId}
+				state={{
+					currentStepIndex,
+					code,
+					output,
+					isRunning,
+					completedStepIndices,
+				}}
+				actions={{
+					onStepChange: setCurrentStepIndex,
+					onCodeChange: setCode,
+					onRun: handleRun,
+					onSubmit: handleSubmit,
+					onShowSolution: handleShowSolution,
+					onShowHint: handleShowHint,
+					onReset: handleReset,
+					onNextLesson: handleNextLesson,
+				}}
+				labels={labels}
 				lang={lang}
-				dict={dict}
+				extensions={extensions}
 			/>
 		</Suspense>
 	);

--- a/apps/playground/app/(main)/[lang]/anza/[lessonId]/anza-client.tsx
+++ b/apps/playground/app/(main)/[lang]/anza/[lessonId]/anza-client.tsx
@@ -39,7 +39,6 @@ export function AnzaClient({ lesson, nextLessonId, lang, dict }: AnzaClientProps
 
 	const [code, setCode] = useState(currentStep.initialCode);
 	const [output, setOutput] = useState("");
-	const [isRunning, setIsRunning] = useState(false);
 	const [completedStepIndices, setCompletedStepIndices] = useState<Set<number>>(new Set());
 
 	// Sync code when step changes
@@ -54,16 +53,6 @@ export function AnzaClient({ lesson, nextLessonId, lang, dict }: AnzaClientProps
 	}, [lesson.id]);
 
 	const executor = new Executor("nuru", useNuru);
-
-	// Call useNuru at top level
-	// const nuru = useNuru(executor.outputHandler);
-
-	// Sync nuru instance with executor
-	// useEffect(() => {
-	// 	if (nuru) {
-	// 		executor.setInstance(nuru);
-	// 	}
-	// }, [nuru, executor]);
 
 	useEffect(() => {
 		executor.onOutput((text, isError) => {
@@ -91,7 +80,6 @@ export function AnzaClient({ lesson, nextLessonId, lang, dict }: AnzaClientProps
 	}, [currentStep.solution, currentStepIndex]);
 
 	const handleRun = async () => {
-		setIsRunning(true);
 		if (executor.onBeforeRun) {
 			executor.onBeforeRun();
 		}
@@ -101,8 +89,6 @@ export function AnzaClient({ lesson, nextLessonId, lang, dict }: AnzaClientProps
 			checkSolution(code);
 		} catch (error) {
 			setOutput(`${dict.playground.error}${error}`);
-		} finally {
-			setIsRunning(false);
 		}
 	};
 
@@ -175,7 +161,6 @@ export function AnzaClient({ lesson, nextLessonId, lang, dict }: AnzaClientProps
 					currentStepIndex,
 					code,
 					output,
-					isRunning,
 					completedStepIndices,
 				}}
 				actions={{

--- a/apps/playground/components/playground/code-editor.tsx
+++ b/apps/playground/components/playground/code-editor.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import CodeMirror from "@uiw/react-codemirror";
-import { nuruLanguage } from "@/lib/nuru-syntax";
 import { EditorView } from "@codemirror/view";
+import { Extension } from "@codemirror/state";
 import * as lezerHighlight from "@lezer/highlight";
 const { tags: t } = lezerHighlight;
 import { createTheme } from "@uiw/codemirror-themes";
@@ -14,6 +14,7 @@ interface CodeEditorProps {
 	onChange?: (code: string) => void;
 	theme?: "dark" | "light" | CreateThemeOptions;
 	readOnly?: boolean;
+	extensions?: Extension[];
 }
 
 // Custom dark theme matching our design
@@ -111,6 +112,7 @@ export function CodeEditor({
 	onChange,
 	theme: themeProp,
 	readOnly = false,
+	extensions = [],
 }: CodeEditorProps) {
 	const { theme: currentTheme, forcedTheme } = useTheme();
 	const theme = (themeProp || forcedTheme || currentTheme) as "light" | "dark" || "dark";
@@ -121,7 +123,7 @@ export function CodeEditor({
 				value={code}
 				height="100%"
 				theme={getTheme(theme)}
-				extensions={[nuruLanguage, editorBaseTheme, EditorView.lineWrapping]}
+				extensions={[...extensions, editorBaseTheme, EditorView.lineWrapping]}
 				onChange={(value) => onChange?.(value)}
 				editable={!readOnly}
 				readOnly={readOnly}

--- a/apps/playground/components/playground/code-panel.tsx
+++ b/apps/playground/components/playground/code-panel.tsx
@@ -17,6 +17,8 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Dictionary } from "@/app/(main)/[lang]/dictionaries";
+import { PlaygroundLabels } from "@/types/playground";
+import { Extension } from "@codemirror/state";
 
 interface CodePanelProps {
 	code: string;
@@ -31,7 +33,8 @@ interface CodePanelProps {
 	mobileExtra?: React.ReactNode;
 	theme?: "light" | "dark";
 	lang: "en" | "sw";
-	dict: Dictionary;
+	labels: PlaygroundLabels;
+	extensions?: Extension[];
 }
 
 export function CodePanel({
@@ -47,7 +50,8 @@ export function CodePanel({
 	mobileExtra,
   theme,
   lang,
-  dict
+  labels,
+  extensions
 }: CodePanelProps) {
 	const isDev = process.env.NODE_ENV === "development";
 
@@ -66,7 +70,7 @@ export function CodePanel({
 						</Button>
 					</TooltipTrigger>
 					<TooltipContent side="top" className="text-[10px] uppercase font-bold tracking-wider">
-						{dict.codePanel.reset}
+						{labels.reset}
 					</TooltipContent>
 				</Tooltip>
 
@@ -82,7 +86,7 @@ export function CodePanel({
 						</Button>
 					</TooltipTrigger>
 					<TooltipContent side="top" className="text-[10px] uppercase font-bold tracking-wider">
-						{dict.codePanel.hint}
+						{labels.hint}
 					</TooltipContent>
 				</Tooltip>
 
@@ -99,7 +103,7 @@ export function CodePanel({
 							</Button>
 						</TooltipTrigger>
 						<TooltipContent side="top" className="text-[10px] uppercase font-bold tracking-wider">
-							{dict.codePanel.showSolution}
+							{labels.showSolution}
 						</TooltipContent>
 					</Tooltip>
 				)}
@@ -112,7 +116,7 @@ export function CodePanel({
 					className="h-8 bg-primary px-3 text-[11px] font-black tracking-wider uppercase text-primary-foreground shadow-lg shadow-primary/20 hover:bg-primary/90 hover:scale-[1.02] active:scale-95 transition-all flex items-center gap-2"
 				>
 					<Play className="h-3 w-3 fill-current" />
-					RUN
+					{labels.run}
 				</Button>
 			</div>
 		</TooltipProvider>
@@ -122,7 +126,7 @@ export function CodePanel({
 	if (isMobile) {
 		return (
 			<div className="bg-background relative flex h-full flex-col">
-				<CodeEditor code={code} onChange={onCodeChange} theme={theme}/>
+				<CodeEditor code={code} onChange={onCodeChange} theme={theme} extensions={extensions}/>
 				<div className="absolute bottom-3 right-3 z-10">
 					{actions}
 				</div>
@@ -136,13 +140,13 @@ export function CodePanel({
 			<ResizablePanelGroup direction="vertical" className="flex-1">
 				<ResizablePanel defaultSize={60} minSize={30}>
 					<div className="relative h-full">
-						<CodeEditor code={code} onChange={onCodeChange} theme={theme} />
+						<CodeEditor code={code} onChange={onCodeChange} theme={theme} extensions={extensions} />
 						<div className="absolute bottom-3 right-3 z-10">{actions}</div>
 					</div>
 				</ResizablePanel>
 				<ResizableHandle withHandle />
 				<ResizablePanel defaultSize={40} minSize={15}>
-					<OutputPanel output={output} showToolbar={false} dict={dict} />
+					<OutputPanel output={output} showToolbar={false} labels={labels} />
 				</ResizablePanel>
 			</ResizablePanelGroup>
 		</div>

--- a/apps/playground/components/playground/lesson-panel.tsx
+++ b/apps/playground/components/playground/lesson-panel.tsx
@@ -9,20 +9,19 @@ import {
 	ArrowRight,
 } from "lucide-react";
 import { ScrollArea } from "@/components/playground/scroll-area";
-import { Lesson, Language } from "@/types/playground";
+import { Lesson, Language, PlaygroundLabels } from "@/types/playground";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import Markdown from "react-markdown";
 import { CodeEditor } from "./code-editor";
 import { Breadcrumbs } from "./breadcrumbs";
-import { Dictionary } from "@/app/(main)/[lang]/dictionaries";
 
 interface LessonPanelProps {
 	lesson: Lesson;
 	currentStepIndex: number;
 	onStepChange: (index: number) => void;
 	lang: Language;
-	dict: Dictionary;
+	labels: PlaygroundLabels;
 	collapsible?: boolean;
 	expanded?: boolean;
 	onToggle?: () => void;
@@ -37,7 +36,7 @@ export function LessonPanel({
 	currentStepIndex,
 	onStepChange,
 	lang,
-	dict,
+	labels,
 	collapsible,
 	expanded,
 	onToggle,
@@ -52,13 +51,13 @@ export function LessonPanel({
 	const breadcrumbs = (
 		<Breadcrumbs
 			items={[
-				{ label: dict.lessonPanel.lessons, href: `/${lang}/anza` },
+				{ label: labels.lessons, href: `/${lang}/anza` },
 				{
 					label: lesson.title[lang] || lesson.title.sw,
 					href: `/${lang}/anza/${lesson.id}`,
 				},
 				{
-					label: `${dict.lessonPanel.step} ${currentStepIndex + 1}`,
+					label: `${labels.step} ${currentStepIndex + 1}`,
 					current: true,
 				},
 			]}
@@ -75,7 +74,7 @@ export function LessonPanel({
 				<div className="flex items-center gap-2">
 					<div className="bg-primary/30 h-px w-8" />
 					<span className="text-muted-foreground font-mono text-[10px] tracking-widest uppercase">
-						{dict.lessonPanel.step} {currentStepIndex + 1} OF{" "}
+						{labels.step} {currentStepIndex + 1} {labels.of}{" "}
 						{lesson.steps.length}
 					</span>
 				</div>
@@ -92,12 +91,12 @@ export function LessonPanel({
 					{isCompleted ? (
 						<>
 							<CheckCircle2 className="h-3 w-3 stroke-3" />
-							{dict.lessonPanel.completed}
+							{labels.completed}
 						</>
 					) : (
 						<>
 							<div className="bg-muted-foreground/40 h-1.5 w-1.5 animate-pulse rounded-full" />
-							{dict.lessonPanel.incomplete}
+							{labels.incomplete}
 						</>
 					)}
 				</div>
@@ -117,7 +116,7 @@ export function LessonPanel({
 				className="border-border/50 bg-background/50 hover:bg-muted h-9 px-3 text-xs font-bold transition-all"
 			>
 				<ChevronLeft className="mr-1.5 h-4 w-4" />
-				{dict.lessonPanel.back}
+				{labels.back}
 			</Button>
 
 			<div className="mx-auto flex flex-col items-center gap-2">
@@ -148,7 +147,7 @@ export function LessonPanel({
 					onClick={onNextLesson}
 					className="h-9 animate-pulse bg-green-600 px-4 text-xs font-bold text-white shadow-lg shadow-green-600/20 hover:bg-green-700"
 				>
-					{dict.lessonPanel.nextLesson}
+					{labels.nextLesson}
 					<ArrowRight className="ml-1.5 h-4 w-4" />
 				</Button>
 			) : (
@@ -164,8 +163,8 @@ export function LessonPanel({
 					className="bg-primary hover:bg-primary/90 h-9 px-4 text-xs font-bold shadow-md transition-all hover:translate-x-0.5 active:translate-x-0"
 				>
 					{currentStepIndex === lesson.steps.length - 1
-						? dict.lessonPanel.finish
-						: dict.lessonPanel.next}
+						? labels.finish
+						: labels.next}
 					<ChevronRight className="ml-1.5 h-4 w-4" />
 				</Button>
 			)}
@@ -220,10 +219,10 @@ export function LessonPanel({
 									<div className="mt-6 rounded-xl border border-yellow-500/20 bg-yellow-500/5 p-4 shadow-sm">
 										<h4 className="text-foreground mb-2 flex items-center gap-2 text-sm font-bold tracking-tight uppercase">
 											<Lightbulb className="h-4 w-4 text-yellow-500" />
-											{dict.lessonPanel.yourTask}
+											{labels.yourTask}
 										</h4>
 										<p className="text-muted-foreground text-sm leading-normal italic">
-											{step.task[lang]}
+											{step.task[lang] || step.task.sw}
 										</p>
 									</div>
 								)}
@@ -309,7 +308,7 @@ export function LessonPanel({
 										<div className="flex items-center justify-between border-b border-yellow-500/10 bg-yellow-500/10 px-3 py-2">
 											<h4 className="flex items-center gap-1.5 text-[10px] font-black tracking-widest text-yellow-600 uppercase dark:text-yellow-500">
 												<Lightbulb className="h-3 w-3" />
-												{dict.lessonPanel.yourTask}
+												{labels.yourTask}
 											</h4>
 										</div>
 										<div className="p-4">

--- a/apps/playground/components/playground/output-panel.tsx
+++ b/apps/playground/components/playground/output-panel.tsx
@@ -3,7 +3,7 @@
 import { Play, Send, Eye, Terminal } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/playground/scroll-area"
-import { Dictionary } from "@/app/(main)/[lang]/dictionaries"
+import { PlaygroundLabels } from "@/types/playground"
 
 interface OutputPanelProps {
   output: string
@@ -11,41 +11,41 @@ interface OutputPanelProps {
   onSubmit?: () => void
   onShowSolution?: () => void
   showToolbar?: boolean
-  dict: Dictionary
+  labels: PlaygroundLabels
 }
 
-export function OutputPanel({ output, onRun, onSubmit, onShowSolution, showToolbar = true, dict }: OutputPanelProps) {
+export function OutputPanel({ output, onRun, onSubmit, onShowSolution, showToolbar = true, labels }: OutputPanelProps) {
   return (
     <div className="flex flex-col h-full bg-background overflow-hidden border-t border-border/20">
       <div className="flex items-center justify-between px-4 py-2 bg-muted/30 border-b border-border/50">
         <div className="flex items-center gap-2.5">
-          
+
           <div className="flex items-center gap-1.5 ml-1">
             <Terminal className="w-3 h-3 text-muted-foreground" />
             <span className="text-[10px] font-black tracking-widest text-muted-foreground uppercase font-mono">
-              Terminal
+              {labels.terminal}
             </span>
           </div>
         </div>
-        
+
         {showToolbar && (
           <div className="flex items-center gap-2">
             <Button onClick={onSubmit} size="sm" className="bg-primary hover:bg-primary/90 text-primary-foreground h-6 px-2 text-[10px] font-bold">
               <Send className="w-2.5 h-2.5 mr-1" />
-              {dict.outputPanel.submit}
+              {labels.testing}
             </Button>
             <Button variant="secondary" size="sm" onClick={onRun} className="h-6 px-2 text-[10px] font-bold">
               <Play className="w-2.5 h-2.5 mr-1" />
-              {dict.outputPanel.run}
+              {labels.run}
             </Button>
             <Button variant="secondary" size="sm" onClick={onShowSolution} className="h-6 px-2 text-[10px] font-bold">
               <Eye className="w-2.5 h-2.5 mr-1" />
-              {dict.outputPanel.solution}
+              {labels.showSolution}
             </Button>
           </div>
         )}
       </div>
-      
+
       <ScrollArea className="flex-1">
         <div className="p-5">
           {output ? (
@@ -61,7 +61,7 @@ export function OutputPanel({ output, onRun, onSubmit, onShowSolution, showToolb
             </pre>
           ) : (
             <p className="text-[13px] text-muted-foreground/60 italic font-mono uppercase tracking-tight">
-              {dict.outputPanel.placeholder}
+              {labels.outputPlaceholder}
             </p>
           )}
         </div>

--- a/apps/playground/components/playground/playground.tsx
+++ b/apps/playground/components/playground/playground.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import { useRef, useState, useEffect, useCallback } from "react";
+import { useRef, useState } from "react";
 import type { ImperativePanelHandle } from "react-resizable-panels";
 import { LessonPanel } from "./lesson-panel";
 import { CodePanel } from "./code-panel";
@@ -11,69 +10,27 @@ import {
 	ResizablePanel,
 	ResizablePanelGroup,
 } from "@/components/playground/resizable";
-import { Button } from "@/components/ui/button";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { PlaygroundProps } from "@/types/playground";
-import confetti from "canvas-confetti";
 import { CheckCircle2 } from "lucide-react";
 
 export function Playground({
 	lesson,
-	executor,
+	state,
+	actions,
+	labels,
 	theme = "dark",
-	nextLessonId,
 	lang,
-	dict,
+	extensions,
 }: PlaygroundProps) {
-	const router = useRouter();
-	const searchParams = useSearchParams();
 	const isMobile = useIsMobile();
-	const [currentStepIndex, setCurrentStepIndex] = useState(0);
-
-	// Initial step from URL
-	useEffect(() => {
-		const stepId = searchParams.get("step");
-		if (stepId) {
-			const index = lesson.steps.findIndex((s) => s.id === stepId);
-			if (index !== -1) {
-				setCurrentStepIndex(index);
-			}
-		}
-	}, [searchParams, lesson.steps]);
-
-	const currentStep = lesson.steps[currentStepIndex];
-
-	const [code, setCode] = useState(currentStep.initialCode);
-	const [output, setOutput] = useState("");
-	const [isRunning, setIsRunning] = useState(false);
-	const [completedStepIndices, setCompletedStepIndices] = useState<Set<number>>(new Set());
 	const [lessonExpanded, setLessonExpanded] = useState(!isMobile);
 	const lessonPanelRef = useRef<ImperativePanelHandle>(null);
 	const codePanelRef = useRef<ImperativePanelHandle>(null);
 	const bottomPanelRef = useRef<ImperativePanelHandle>(null);
 
-	// Sync code when step changes
-	useEffect(() => {
-		setCode(currentStep.initialCode);
-		setOutput("");
-	}, [currentStepIndex, lesson.id, currentStep.initialCode]);
-
-	// Reset progress when lesson changes
-	useEffect(() => {
-		setCompletedStepIndices(new Set());
-	}, [lesson.id]);
-
-	const isCurrentStepCompleted = completedStepIndices.has(currentStepIndex);
-
-	useEffect(() => {
-		executor.onOutput((output, isError) => {
-			setOutput((prev) => {
-				if (prev) {
-					return prev + `\n${output}`;
-				} else return output;
-			});
-		});
-	}, [executor]);
+	const currentStep = lesson.steps[state.currentStepIndex];
+	const isCurrentStepCompleted = state.completedStepIndices.has(state.currentStepIndex);
 
 	const handleLessonToggle = () => {
 		const lessonPanel = lessonPanelRef.current;
@@ -96,79 +53,6 @@ export function Playground({
 		}
 	};
 
-	const checkSolution = useCallback((currentCode: string) => {
-		if (!currentStep.solution) return false;
-		
-		// Simple normalization: remove whitespace and comments
-		const normalize = (s: string) => s.replace(/\/\/.*$/gm, "").replace(/\s/g, "");
-		const isCorrect = normalize(currentCode) === normalize(currentStep.solution);
-		
-		if (isCorrect) {
-			setCompletedStepIndices(prev => new Set(prev).add(currentStepIndex));
-			confetti({
-				particleCount: 100,
-				spread: 70,
-				origin: { y: 0.6 },
-				colors: ["#22c55e", "#10b981", "#3b82f6"]
-			});
-		}
-		return isCorrect;
-	}, [currentStep.solution, currentStepIndex]);
-
-	const handleRun = async () => {
-		setIsRunning(true);
-		if (executor.onBeforeRun) {
-			executor.onBeforeRun();
-		}
-		setOutput("");
-		try {
-			await executor.run(code);
-			checkSolution(code);
-		} catch (error) {
-			setOutput(`${dict.playground.error}${error}`);
-		} finally {
-			setIsRunning(false);
-		}
-	};
-
-	const handleSubmit = async () => {
-		setOutput(dict.playground.testing);
-		try {
-			const result = await executor.submit(code);
-			setOutput(result);
-		} catch (error) {
-			setOutput(`${dict.playground.error}${error}`);
-		}
-	};
-
-	const handleShowSolution = () => {
-		if (currentStep.solution) {
-			setCode(currentStep.solution);
-		} else if (executor.getSolution) {
-			setCode(executor.getSolution());
-		}
-	};
-
-	const handleShowHint = () => {
-		// Basic hint: show the first line of the solution or a generic tip
-		const hintMessage = dict.playground.hint;
-		
-		setOutput(prev => prev ? `${prev}\n\n${hintMessage}` : hintMessage);
-	};
-
-	const handleReset = () => {
-		setCode(currentStep.initialCode);
-		setOutput("");
-	};
-
-	const handleNextLesson = () => {
-		if (nextLessonId) {
-			router.push(`/${lang}/anza/${nextLessonId}`);
-		} else {
-			router.push(`/${lang}/anza`);
-		}
-	};
-
 	if (isMobile) {
 		return (
 			<div className="flex max-h-full flex-1 flex-col overflow-hidden bg-background">
@@ -186,16 +70,16 @@ export function Playground({
 					>
 						<LessonPanel
 							lesson={lesson}
-							currentStepIndex={currentStepIndex}
-							onStepChange={setCurrentStepIndex}
+							currentStepIndex={state.currentStepIndex}
+							onStepChange={actions.onStepChange}
 							lang={lang}
-							dict={dict}
+							labels={labels}
 							collapsible
 							expanded={lessonExpanded}
 							onToggle={handleLessonToggle}
 							isCompleted={isCurrentStepCompleted}
-							completedStepIndices={completedStepIndices}
-							onNextLesson={handleNextLesson}
+							completedStepIndices={state.completedStepIndices}
+							onNextLesson={actions.onNextLesson}
 						/>
 					</ResizablePanel>
 					{!lessonExpanded && (
@@ -245,18 +129,19 @@ export function Playground({
 						minSize={15}
 					>
 						<CodePanel
-							code={code}
-							output={output}
-							onCodeChange={setCode}
-							onRun={handleRun}
-							onSubmit={handleSubmit}
-							onShowSolution={handleShowSolution}
-							onShowHint={handleShowHint}
-							onReset={handleReset}
+							code={state.code}
+							output={state.output}
+							onCodeChange={actions.onCodeChange}
+							onRun={actions.onRun}
+							onSubmit={actions.onSubmit}
+							onShowSolution={actions.onShowSolution}
+							onShowHint={actions.onShowHint}
+							onReset={actions.onReset}
 							isMobile
 							theme={theme}
 							lang={lang}
-							dict={dict}
+							labels={labels}
+							extensions={extensions}
 						/>
 					</ResizablePanel>
 					<ResizableHandle withHandle />
@@ -267,7 +152,7 @@ export function Playground({
 						defaultSize={isMobile ? 10 : 40}
 						minSize={10}
 					>
-						<OutputPanel output={output} showToolbar={false} dict={dict} />
+						<OutputPanel output={state.output} showToolbar={false} labels={labels} />
 					</ResizablePanel>
 				</ResizablePanelGroup>
 			</div>
@@ -280,33 +165,33 @@ export function Playground({
 				<ResizablePanel defaultSize={50} minSize={20}>
 					<LessonPanel
 						lesson={lesson}
-						currentStepIndex={currentStepIndex}
-						onStepChange={setCurrentStepIndex}
+						currentStepIndex={state.currentStepIndex}
+						onStepChange={actions.onStepChange}
 						lang={lang}
-						dict={dict}
+						labels={labels}
 						isCompleted={isCurrentStepCompleted}
-						completedStepIndices={completedStepIndices}
-						onNextLesson={handleNextLesson}
+						completedStepIndices={state.completedStepIndices}
+						onNextLesson={actions.onNextLesson}
 					/>
 				</ResizablePanel>
 				<ResizableHandle withHandle />
 				<ResizablePanel defaultSize={50} minSize={25}>
 					<CodePanel
-						code={code}
-						output={output}
-						onCodeChange={setCode}
-						onRun={handleRun}
-						onSubmit={handleSubmit}
-						onShowSolution={handleShowSolution}
-						onShowHint={handleShowHint}
-						onReset={handleReset}
+						code={state.code}
+						output={state.output}
+						onCodeChange={actions.onCodeChange}
+						onRun={actions.onRun}
+						onSubmit={actions.onSubmit}
+						onShowSolution={actions.onShowSolution}
+						onShowHint={actions.onShowHint}
+						onReset={actions.onReset}
 						theme={theme}
 						lang={lang}
-						dict={dict}
+						labels={labels}
+						extensions={extensions}
 					/>
 				</ResizablePanel>
 			</ResizablePanelGroup>
 		</div>
 	);
 }
-

--- a/apps/playground/lib/executor.ts
+++ b/apps/playground/lib/executor.ts
@@ -26,7 +26,7 @@ export class Executor<LanguageInstace extends Interpreter> {
 		this.options = options;
 	}
 
-	private outputHandler = (text: string, isError: boolean) => {
+	outputHandler = (text: string, isError: boolean) => {
 		if (this.outputBridge) {
 			this.outputBridge(text, isError);
 		} else {
@@ -34,6 +34,10 @@ export class Executor<LanguageInstace extends Interpreter> {
 				`Output received but output handler not regsitered.\noutput:${text}\n call onOuput method`,
 			);
 		}
+	};
+
+	setInstance = (instance: LanguageInstace) => {
+		this.instance = instance;
 	};
 
 	async run(code: string) {

--- a/apps/playground/lib/nuru-syntax.ts
+++ b/apps/playground/lib/nuru-syntax.ts
@@ -57,5 +57,5 @@ export const nuruLanguage = StreamLanguage.define(
 			dontIndentStates: ["comment"],
 			lineComment: "//",
 		},
-	}),
+	} as any),
 );

--- a/apps/playground/types/playground.ts
+++ b/apps/playground/types/playground.ts
@@ -46,7 +46,6 @@ export interface PlaygroundProps {
 		currentStepIndex: number;
 		code: string;
 		output: string;
-		isRunning: boolean;
 		completedStepIndices: Set<number>;
 	};
 	actions: {

--- a/apps/playground/types/playground.ts
+++ b/apps/playground/types/playground.ts
@@ -1,6 +1,4 @@
-import { Executor } from "@/lib/executor";
-import type { Interpreter } from "@/lib/executor";
-import { Dictionary } from "@/app/(main)/[lang]/dictionaries";
+import type { Extension } from "@codemirror/state";
 
 export type Language = "sw" | "en";
 
@@ -20,11 +18,49 @@ export interface Lesson {
 	difficulty?: string;
 }
 
+export interface PlaygroundLabels {
+	run: string;
+	testing: string;
+	error: string;
+	hint: string;
+	reset: string;
+	showSolution: string;
+	nextLesson: string;
+	backToLessons: string;
+	completed: string;
+	step: string;
+	of: string;
+	terminal: string;
+	outputPlaceholder: string;
+	lessons: string;
+	incomplete: string;
+	back: string;
+	next: string;
+	finish: string;
+	yourTask: string;
+}
+
 export interface PlaygroundProps {
 	lesson: Lesson;
-	executor: Executor<Interpreter>;
+	state: {
+		currentStepIndex: number;
+		code: string;
+		output: string;
+		isRunning: boolean;
+		completedStepIndices: Set<number>;
+	};
+	actions: {
+		onStepChange: (index: number) => void;
+		onCodeChange: (code: string) => void;
+		onRun: () => void;
+		onSubmit: () => void;
+		onShowSolution: () => void;
+		onShowHint: () => void;
+		onReset: () => void;
+		onNextLesson: () => void;
+	};
+	labels: PlaygroundLabels;
 	theme?: "light" | "dark";
-	nextLessonId?: string;
 	lang: Language;
-	dict: Dictionary;
+	extensions?: Extension[];
 }


### PR DESCRIPTION
Refactors the playground component to be language agnostic and logic unaware.
- Language agnostic: Previously the component would import nuru's language syntax, now it receives CodeMirror's extensions as a prop so it can work with other languages
- Hoisting application logic: The component would also navigate between lessons, verify solutions and other shabang. All this is hoisted up and now it only provides events that the consumer passes callbacks to. `onNextLesson` , `onCodeChange`  and `onRun` are few examples. 

The goal is to make the component reusable across projects and this is another big step towards that
