### PR TITLE
Refactor/playground UI restructure

### DIFF
--- a/apps/playground/app/(main)/[lang]/anza/[moduleSlug]/[lessonSlug]/page.tsx
+++ b/apps/playground/app/(main)/[lang]/anza/[moduleSlug]/[lessonSlug]/page.tsx
@@ -1,4 +1,4 @@
-import { getModuleBySlug, getAllModules } from "@/lib/lessons.server";
+import { getModuleBySlug, getAllModules, getAllModulesWithLessons } from "@/lib/lessons.server";
 import { AnzaClient } from "../../anza-client";
 import { notFound } from "next/navigation";
 import { getDictionary, Locale } from "@/app/(main)/[lang]/dictionaries";
@@ -13,7 +13,7 @@ interface PageProps {
 export default async function LessonPage({ params }: PageProps) {
 	const { moduleSlug, lessonSlug, lang } = await params;
 	const dict = await getDictionary(lang as Locale);
-	
+
 	let module: Module;
 	try {
 		module = await getModuleBySlug(moduleSlug);
@@ -22,32 +22,38 @@ export default async function LessonPage({ params }: PageProps) {
 		return notFound();
 	}
 
-	// Verify lesson exists
 	const lessonExists = module.lessons.some(s => s.slug === lessonSlug);
 	if (!lessonExists) {
 		return notFound();
 	}
 
 	let allModules: { id: string; slug: string; title: Record<Language, string> }[];
+	let allModulesFull: Module[] = [];
 	try {
-		allModules = await getAllModules();
+		[allModules, allModulesFull] = await Promise.all([
+			getAllModules(),
+			getAllModulesWithLessons(),
+		]);
 	} catch (error) {
 		console.error("Error loading all modules:", error);
 		allModules = [];
+		allModulesFull = [];
 	}
 
 	const currentIndex = allModules.findIndex(l => l.slug === moduleSlug);
-	const nextModuleSlug = currentIndex >= 0 && currentIndex < allModules.length - 1 
-		? allModules[currentIndex + 1].slug 
+	const nextModuleSlug = currentIndex >= 0 && currentIndex < allModules.length - 1
+		? allModules[currentIndex + 1].slug
 		: undefined;
 
 	return (
-		<AnzaClient 
-			module={module} 
+		<AnzaClient
+			module={module}
+			allModules={allModulesFull}
 			lessonSlug={lessonSlug}
-			nextModuleSlug={nextModuleSlug} 
-			lang={lang as Locale} 
-			dict={dict} 
+			nextModuleSlug={nextModuleSlug}
+			lang={lang as Locale}
+			dict={dict}
 		/>
 	);
 }
+

--- a/apps/playground/app/(main)/[lang]/anza/[moduleSlug]/[lessonSlug]/page.tsx
+++ b/apps/playground/app/(main)/[lang]/anza/[moduleSlug]/[lessonSlug]/page.tsx
@@ -27,18 +27,17 @@ export default async function LessonPage({ params }: PageProps) {
 		return notFound();
 	}
 
-	let allModules: { id: string; slug: string; title: Record<Language, string> }[];
+	let allModules: { id: string; slug: string; title: Record<Language, string> }[] = [];
 	let allModulesFull: Module[] = [];
-	try {
-		[allModules, allModulesFull] = await Promise.all([
-			getAllModules(),
-			getAllModulesWithLessons(),
-		]);
-	} catch (error) {
-		console.error("Error loading all modules:", error);
-		allModules = [];
-		allModulesFull = [];
-	}
+	// Fetch independently so a failure in one does NOT empty the sidebar list.
+	await Promise.all([
+		getAllModules()
+			.then((r) => { allModules = r; })
+			.catch((e) => { console.error("getAllModules failed:", e); }),
+		getAllModulesWithLessons()
+			.then((r) => { allModulesFull = r; })
+			.catch((e) => { console.error("getAllModulesWithLessons failed:", e); }),
+	]);
 
 	const currentIndex = allModules.findIndex(l => l.slug === moduleSlug);
 	const nextModuleSlug = currentIndex >= 0 && currentIndex < allModules.length - 1

--- a/apps/playground/app/(main)/[lang]/anza/anza-client.tsx
+++ b/apps/playground/app/(main)/[lang]/anza/anza-client.tsx
@@ -15,13 +15,15 @@ import { nuruLanguage } from "@nuru/ui/lib/nuru-syntax";
 
 interface AnzaClientProps {
 	module: Module;
+	allModules?: Module[];
 	lessonSlug: string;
 	nextModuleSlug?: string;
 	lang: Language;
 	dict: Dictionary;
 }
 
-export function AnzaClient({ module, lessonSlug, nextModuleSlug, lang, dict }: AnzaClientProps) {
+export function AnzaClient({ module, allModules, lessonSlug, nextModuleSlug, lang, dict }: AnzaClientProps) {
+
 	const { theme} = useTheme();
 	const router = useRouter();
 	const currentLessonIndex = useMemo(() => {
@@ -304,7 +306,9 @@ export function AnzaClient({ module, lessonSlug, nextModuleSlug, lang, dict }: A
 			<Playground
 				theme={(theme) as "light" | "dark"}
 				module={module}
+				allModules={allModules}
 				state={{
+
 					currentLessonIndex,
 					code,
 					output,

--- a/apps/playground/app/(main)/[lang]/kozi/[moduleSlug]/page.tsx
+++ b/apps/playground/app/(main)/[lang]/kozi/[moduleSlug]/page.tsx
@@ -1,0 +1,342 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+	ChevronRight,
+	ChevronDown,
+	GraduationCap,
+	Gauge,
+	BookOpen,
+	Clock,
+	Play,
+	Code2,
+	Flame,
+	CheckCircle2,
+	Activity,
+	Flag,
+	Circle,
+} from "lucide-react";
+import { getModuleBySlug } from "@/lib/lessons.server";
+
+export const dynamic = "force-dynamic";
+
+export default async function KoziModulePage({
+	params,
+}: {
+	params: Promise<{ lang: string; moduleSlug: string }>;
+}) {
+	const { lang, moduleSlug } = await params;
+	let mod;
+	try {
+		mod = await getModuleBySlug(moduleSlug);
+	} catch {
+		return notFound();
+	}
+	const title = mod.slug === "misingi-ya-nuru" ? "Nuru Basics" : mod.title[lang as "en" | "sw"] || mod.title.sw;
+	const totalLessons = mod.slug === "misingi-ya-nuru" ? 7 : mod.lessons.length;
+	const firstLessonHref = `/${lang}/anza/${mod.slug}${
+		mod.lessons[0] ? `/${mod.lessons[0].slug}` : ""
+	}`;
+	// Placeholder progress / activity data (UI parity with mockup)
+	const overallPct = 42;
+	const lessonsDone = 7;
+	const timeSpent = "3h 24m";
+	const streakDays = 7;
+	const streakWeek = [true, true, true, true, true, true, false];
+	const visibleLessons = [
+		{ number: 2, title: "Hello Nuru", description: "Jifunze kutoa matokeo kwenye skrini kwa kutumia andika().", pct: 100, tint: "bg-blue-50 text-blue-600", label: "2" },
+		{ number: 3, title: "Variables", description: "Elewa vigezo na jinsi ya kuhifadhi na kutumia data.", pct: 100, tint: "bg-emerald-50 text-emerald-600", label: "(x)" },
+		{ number: 4, title: "Types & Data", description: "Jifunze aina za data kama namba, maandishi na boolean.", pct: 100, tint: "bg-violet-50 text-violet-600", icon: BookOpen },
+		{ number: 5, title: "Math Operations", description: "Fanya mahesabu ya msingi kwa urahisi.", pct: 100, tint: "bg-amber-50 text-amber-600", label: "+" },
+		{ number: 6, title: "Conditions", description: "Tumia masharti kufanya maamuzi katika programu.", pct: 86, tint: "bg-orange-50 text-orange-600", label: "if" },
+		{ number: 7, title: "Loops", description: "Rudia maagizo kwa kutumia loops na kurahisisha kazi.", pct: 75, tint: "bg-blue-50 text-blue-600", label: "↻" },
+	];
+
+	const recentActivity = [
+		{ title: "Functions", time: "Today • 10:24 AM" },
+		{ title: "Loops", time: "Yesterday • 4:15 PM" },
+		{ title: "Conditions", time: "Yesterday • 11:42 AM" },
+		{ title: "Math Operations", time: "2 days ago • 3:30 PM" },
+		{ title: "Types & Data", time: "3 days ago • 9:18 AM" },
+	];
+
+	const milestones = [
+		{ label: "Finish Nuru Basics", meta: "58% of learners", tint: "bg-blue-100 text-blue-600" },
+		{ label: "Complete all exercises", meta: "42% of learners", tint: "bg-violet-100 text-violet-600" },
+		{ label: "7-day learning streak", meta: "35% of learners", tint: "bg-amber-100 text-amber-600" },
+	];
+
+	return (
+		<main className="min-h-screen bg-white">
+			<div className="mx-auto max-w-[1220px] px-8 pt-6 pb-8">
+				{/* Breadcrumbs */}
+				<nav className="mb-6 flex items-center gap-2 text-[12px] font-medium text-slate-500">
+					<Link href={`/${lang}`} className="hover:text-slate-900">Dashboard</Link>
+					<ChevronRight className="h-3.5 w-3.5 text-slate-300" />
+					<Link href={`/${lang}/kozi/${mod.slug}`} className="hover:text-slate-900">Courses</Link>
+					<ChevronRight className="h-3.5 w-3.5 text-slate-300" />
+					<span className="font-semibold text-slate-900">{title}</span>
+				</nav>
+
+				<div className="grid grid-cols-1 gap-[26px] lg:grid-cols-[1fr_322px]">
+					{/* LEFT MAIN COLUMN */}
+					<div className="space-y-6">
+						{/* Hero card */}
+						<section className="relative min-h-[354px] overflow-hidden rounded-[10px] border border-blue-200 bg-gradient-to-br from-white via-blue-50/20 to-blue-100/60 p-10 shadow-[0_8px_28px_rgba(30,64,175,0.08)]">
+							<div className="absolute inset-0 bg-[radial-gradient(circle_at_78%_23%,rgba(37,99,235,0.12)_0_10px,transparent_11px),radial-gradient(circle_at_66%_37%,rgba(37,99,235,0.14)_0_7px,transparent_8px),radial-gradient(circle_at_94%_31%,rgba(37,99,235,0.10)_0_8px,transparent_9px)]" />
+							<div className="absolute right-0 bottom-0 h-32 w-[55%] rounded-tl-[100%] bg-gradient-to-t from-blue-500/20 via-blue-200/20 to-transparent blur-sm" />
+							<div className="relative z-10 max-w-[480px]">
+								<div className="mb-3 inline-flex items-center gap-2 text-[12px] font-extrabold uppercase text-blue-600">
+									<GraduationCap className="h-4 w-4" />
+									Course
+								</div>
+								<h1 className="mb-4 text-[40px] leading-none font-extrabold tracking-tight text-[#111a44]">
+									{title}
+								</h1>
+								<p className="mb-8 max-w-[430px] text-[13.5px] leading-7 text-slate-500">
+									Jifunze misingi ya Nuru hatua kwa hatua. Kozi hii itakusaidia
+									kujenga uelewa thabiti wa programu kutoka mwanzo hadi mwisho.
+								</p>
+								<div className="mb-8 flex flex-wrap gap-0">
+									<Stat icon={Gauge} label="Progress" value={`${overallPct}%`} tint="text-blue-600" />
+									<Stat icon={BookOpen} label="Lessons" value={`${lessonsDone}/${totalLessons}`} tint="text-emerald-600" />
+									<Stat icon={Clock} label="Time Spent" value={timeSpent} tint="text-amber-600" />
+								</div>
+								<div className="flex flex-wrap gap-3">
+									<Link
+										href={firstLessonHref}
+										className="inline-flex h-10 items-center gap-2 rounded-[6px] bg-blue-600 px-5 text-[13px] font-semibold text-white shadow-sm hover:bg-blue-700"
+									>
+										<Play className="h-4 w-4 fill-current" />
+										Continue Learning
+									</Link>
+									<Link
+										href={`/${lang}/playground`}
+										className="inline-flex h-10 items-center gap-2 rounded-[6px] border border-slate-200 bg-white px-5 text-[13px] font-semibold text-slate-500 shadow-sm hover:bg-slate-50"
+									>
+										<Code2 className="h-4 w-4" />
+										View Playground
+									</Link>
+								</div>
+							</div>
+							{/* Decorative tile */}
+							<div className="pointer-events-none absolute top-[92px] right-[134px] hidden rotate-[-12deg] lg:block">
+								<div className="flex h-[142px] w-[142px] items-center justify-center rounded-[30px] bg-gradient-to-br from-blue-400 via-blue-600 to-blue-800 shadow-[0_32px_55px_rgba(37,99,235,0.34)] ring-1 ring-white/45">
+									<svg className="h-20 w-20 rotate-[12deg] text-white drop-shadow-sm" viewBox="0 0 24 24" fill="none">
+										<path
+											d="M12 2v6m0 8v6M2 12h6m8 0h6M4.93 4.93l4.24 4.24m5.66 5.66l4.24 4.24M4.93 19.07l4.24-4.24m5.66-5.66l4.24-4.24"
+											stroke="currentColor"
+											strokeWidth="2.5"
+											strokeLinecap="round"
+										/>
+									</svg>
+								</div>
+							</div>
+						</section>
+
+						{/* Course Content */}
+						<section>
+							<div className="mb-4 flex items-center justify-between">
+								<div className="flex items-center gap-3">
+									<h2 className="text-[17px] font-extrabold text-[#111a44]">Course Content</h2>
+									<span className="rounded-full border border-slate-200 bg-white px-2.5 py-0.5 text-[11px] font-semibold text-slate-500">
+										{totalLessons} Lessons
+									</span>
+								</div>
+								<button className="inline-flex items-center gap-1 text-[12px] font-semibold text-blue-600 hover:text-blue-700">
+									Expand All <ChevronDown className="h-3.5 w-3.5" />
+								</button>
+							</div>
+							<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+								{visibleLessons.map((lesson, i) => {
+									const source = mod.lessons[lesson.number - 1] || mod.lessons[i] || mod.lessons[0];
+									const isDone = lesson.pct === 100;
+									const Icon = lesson.icon;
+									return (
+										<Link
+											key={lesson.number}
+											href={source ? `/${lang}/anza/${mod.slug}/${source.slug}` : firstLessonHref}
+											className="group rounded-[10px] border border-slate-200 bg-white p-4 shadow-[0_8px_18px_rgba(15,23,42,0.04)] transition-all hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-md"
+										>
+											<div className="mb-5 flex items-start gap-4">
+												<div className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-[10px] text-[18px] font-bold ${lesson.tint}`}>
+													{Icon ? <Icon className="h-5 w-5" /> : lesson.label}
+												</div>
+												<div className="min-w-0 flex-1">
+													<h3 className="truncate text-[13.5px] font-extrabold text-[#111a44]">
+														{lesson.number}. {lesson.title}
+													</h3>
+													<p className="mt-1.5 line-clamp-2 text-[11.5px] leading-5 text-slate-500">
+														{lesson.description}
+													</p>
+												</div>
+											</div>
+											<div className="flex items-center gap-2">
+												<div className="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-100">
+													<div
+														className="h-full rounded-full bg-blue-600"
+														style={{ width: `${lesson.pct}%` }}
+													/>
+												</div>
+												<span className="w-8 text-right text-[11px] font-semibold text-slate-500">{lesson.pct}%</span>
+												{isDone ? (
+													<CheckCircle2 className="h-4 w-4 text-emerald-500" />
+												) : (
+													<Circle className="h-4 w-4 text-slate-300" />
+												)}
+											</div>
+										</Link>
+									);
+								})}
+							</div>
+						</section>
+
+						{/* Practice CTA */}
+						<section className="flex flex-col items-start justify-between gap-4 rounded-[10px] border border-slate-200 bg-white px-5 py-4 shadow-[0_8px_18px_rgba(15,23,42,0.04)] sm:flex-row sm:items-center">
+							<div className="flex items-center gap-4">
+								<div className="flex h-10 w-10 items-center justify-center rounded-[8px] bg-blue-600 text-white">
+									<Code2 className="h-5 w-5" />
+								</div>
+								<div>
+									<h3 className="text-[13.5px] font-extrabold text-[#111a44]">
+										Practice in the Playground
+									</h3>
+									<p className="text-[12px] text-slate-500">
+										Tumia maarifa yako kwenye Nuru Playground. Jaribu, cheza na jifunze zaidi!
+									</p>
+								</div>
+							</div>
+							<Link
+								href={`/${lang}/playground`}
+								className="inline-flex h-9 min-w-[140px] items-center justify-center gap-2 rounded-[6px] border border-slate-200 bg-white px-4 text-[12.5px] font-semibold text-slate-600 shadow-sm hover:bg-slate-50"
+							>
+								<Code2 className="h-4 w-4" />
+								Open Playground
+							</Link>
+						</section>
+					</div>
+
+					{/* RIGHT SIDEBAR */}
+					<aside className="space-y-4">
+						{/* Streak */}
+						<div className="rounded-[10px] border border-slate-200 bg-white p-5 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+							<div className="flex items-center gap-3">
+								<div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-orange-50">
+									<Flame className="h-6 w-6 text-orange-500" />
+								</div>
+								<div>
+									<div className="text-[12px] font-medium text-slate-500">Current Streak</div>
+									<div className="flex items-baseline gap-1">
+										<span className="text-3xl font-extrabold text-slate-900">{streakDays}</span>
+										<span className="text-[12px] text-slate-500">days</span>
+									</div>
+								</div>
+							</div>
+							<p className="mt-3 text-[12px] leading-relaxed text-slate-500">
+								Keep it up! You're building an amazing habit.
+							</p>
+							<div className="mt-4 flex items-center justify-between">
+								{["M", "T", "W", "T", "F", "S", "S"].map((d, i) => (
+									<div key={i} className="flex flex-col items-center gap-1.5">
+										<div
+											className={`flex h-7 w-7 items-center justify-center rounded-full ${
+												streakWeek[i]
+													? "bg-blue-600 text-white"
+													: "border border-slate-200 bg-white text-slate-300"
+											}`}
+										>
+											{streakWeek[i] && <CheckCircle2 className="h-4 w-4" />}
+										</div>
+										<span className="text-[10px] font-semibold text-slate-400">{d}</span>
+									</div>
+								))}
+							</div>
+						</div>
+
+						{/* Recent activity */}
+						<div className="rounded-[10px] border border-slate-200 bg-white p-5 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+							<div className="mb-4 flex items-center justify-between">
+								<div className="flex items-center gap-2">
+									<Activity className="h-4 w-4 text-slate-400" />
+									<h3 className="text-[13px] font-bold text-slate-900">Recent Activity</h3>
+								</div>
+								<Link
+									href={`/${lang}/masomo/progress`}
+									className="text-[11px] font-semibold text-blue-600 hover:text-blue-700"
+								>
+									View all
+								</Link>
+							</div>
+							<ul className="space-y-3">
+								{recentActivity.map((a, i) => (
+									<li key={i} className="flex items-start gap-3">
+										<CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
+										<div className="min-w-0 flex-1">
+											<div className="text-[12.5px] text-slate-700">
+												<span className="font-semibold text-slate-900">Completed:</span> {a.title}
+											</div>
+											<div className="text-[11px] text-slate-400">{a.time}</div>
+										</div>
+									</li>
+								))}
+							</ul>
+						</div>
+
+						{/* Milestones */}
+						<div className="rounded-[10px] border border-slate-200 bg-white p-5 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+							<div className="mb-4 flex items-center gap-2">
+								<Flag className="h-4 w-4 text-slate-400" />
+								<h3 className="text-[13px] font-bold text-slate-900">Upcoming Milestones</h3>
+							</div>
+							<ul className="space-y-3">
+								{milestones.map((m, i) => (
+									<li key={i} className="flex items-center gap-3">
+										<Circle className="h-4 w-4 text-slate-300" />
+										<div className="min-w-0 flex-1">
+											<div className="text-[12.5px] font-semibold text-slate-800">{m.label}</div>
+											<div className="text-[11px] text-slate-400">{m.meta}</div>
+										</div>
+										<div className={`flex h-8 w-8 items-center justify-center rounded-lg ${m.tint}`}>
+											<Flag className="h-4 w-4" />
+										</div>
+									</li>
+								))}
+							</ul>
+							<Link
+								href={`/${lang}/masomo/progress`}
+								className="mt-4 flex items-center justify-between text-[12px] font-semibold text-blue-600 hover:text-blue-700"
+							>
+								View all milestones <ChevronRight className="h-3.5 w-3.5" />
+							</Link>
+						</div>
+					</aside>
+				</div>
+			</div>
+		</main>
+	);
+}
+
+function Stat({
+	icon: Icon,
+	label,
+	value,
+	tint,
+}: {
+	icon: any;
+	label: string;
+	value: string;
+	tint: string;
+}) {
+	return (
+		<div className="flex items-center gap-3 border-r border-slate-200 pr-8 last:border-r-0 last:pr-0">
+			<div className={`flex h-8 w-8 items-center justify-center rounded-full border border-blue-600/20 bg-white ${tint}`}>
+				<Icon className="h-5 w-5" />
+			</div>
+			<div>
+				<div className="text-[10.5px] font-semibold text-slate-500">
+					{label}
+				</div>
+				<div className="text-[18px] leading-tight font-extrabold text-[#111a44]">{value}</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/playground/app/(main)/[lang]/kozi/[moduleSlug]/ramani/page.tsx
+++ b/apps/playground/app/(main)/[lang]/kozi/[moduleSlug]/ramani/page.tsx
@@ -1,0 +1,283 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+	BarChart3,
+	BookOpen,
+	Box,
+	CheckCircle2,
+	ChevronDown,
+	ChevronRight,
+	Circle,
+	CircleDot,
+	Clock,
+	Code2,
+	Expand,
+	Layers,
+	Lock,
+	Play,
+	Sparkles,
+	Sprout,
+} from "lucide-react";
+import { getModuleBySlug, getAllModulesWithLessons } from "@/lib/lessons.server";
+
+export const dynamic = "force-dynamic";
+
+type Status = "completed" | "in-progress" | "locked";
+
+const moduleTitles = [
+	"Karibu Nuru",
+	"Hello Nuru",
+	"Variables",
+	"Types & Data",
+	"Math Operations",
+	"Conditions",
+	"Loops",
+	"Functions",
+];
+
+const lessonTitles: Record<number, string[]> = {
+	0: ["Karibu kwenye Nuru", "Nuru ni nini?", "Jinsi Nuru inavyofanya kazi"],
+	1: ["Hello World", "Outputting Results (andika)", "Mistari ya Maelekezo", "Maoni (Comments)", "Zoezi: Chapisha sentensi yako"],
+	2: ["Variables ni nini?", "Kutengeneza Variable", "Kutumia Variable", "Zoezi: Umri na Jina"],
+	3: ["Aina za Data", "String (Maandishi)", "Number (Namba)", "Zoezi: Taarifa Binafsi"],
+};
+
+const trackIcons = [Sprout, Code2, Box, Layers, Sparkles, Sparkles, Sparkles, Sparkles];
+const trackTints = [
+	"border-emerald-100 bg-emerald-500 text-white shadow-emerald-500/25",
+	"border-blue-100 bg-blue-500 text-white shadow-blue-500/25",
+	"border-violet-100 bg-violet-100 text-violet-600 shadow-violet-500/10",
+	"border-orange-100 bg-orange-100 text-orange-500 shadow-orange-500/10",
+	"border-slate-100 bg-slate-100 text-slate-400 shadow-slate-500/5",
+	"border-slate-100 bg-slate-100 text-slate-400 shadow-slate-500/5",
+	"border-slate-100 bg-slate-100 text-slate-400 shadow-slate-500/5",
+	"border-slate-100 bg-slate-100 text-slate-400 shadow-slate-500/5",
+];
+
+export default async function CurriculumMapPage({
+	params,
+}: {
+	params: Promise<{ lang: string; moduleSlug: string }>;
+}) {
+	const { lang, moduleSlug } = await params;
+	let mod;
+	try {
+		mod = await getModuleBySlug(moduleSlug);
+	} catch {
+		return notFound();
+	}
+	const allModulesRaw = await getAllModulesWithLessons();
+	const title = mod.slug === "misingi-ya-nuru" ? "Nuru Basics" : mod.title[lang as "en" | "sw"] || mod.title.sw;
+	const modules = Array.from({ length: 8 }, (_, i) => {
+		const source = allModulesRaw[i] || allModulesRaw[0] || mod;
+		const lessons = lessonTitles[i] || (source.lessons || []).slice(0, 4).map((l) => l.title[lang as "en" | "sw"] || l.title.sw);
+		return {
+			id: source.id || String(i),
+			slug: source.slug || mod.slug,
+			title: moduleTitles[i] || source.title?.[lang as "en" | "sw"] || source.title?.sw || `Module ${i + 1}`,
+			lessons: lessons.length ? lessons : ["Lesson one", "Lesson two", "Lesson three", "Lesson four"],
+			status: (i === 0 ? "completed" : i === 1 ? "in-progress" : "locked") as Status,
+		};
+	});
+
+	const nextHref = `/${lang}/anza/${mod.slug}/${mod.lessons[1]?.slug || mod.lessons[0]?.slug || ""}`;
+
+	return (
+		<main className="min-h-screen bg-white">
+			<div className="mx-auto max-w-[1280px] px-4 pt-4 pb-8">
+				<nav className="mb-3 flex items-center gap-2 px-2 text-[13px] font-medium text-slate-500">
+					<Link href={`/${lang}/kozi/${mod.slug}`} className="hover:text-slate-900">
+						{title}
+					</Link>
+					<ChevronRight className="h-3.5 w-3.5 text-slate-300" />
+					<span className="font-bold text-[#111a44]">Curriculum Map</span>
+				</nav>
+
+				<div className="grid grid-cols-1 gap-4 lg:grid-cols-[246px_minmax(0,1fr)_286px]">
+					<aside className="overflow-hidden rounded-[10px] border border-slate-200 bg-white shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+						<div className="border-b border-slate-100 p-4">
+							<div className="flex items-center gap-2.5">
+								<div className="flex h-7 w-7 items-center justify-center rounded-[6px] bg-blue-50 text-blue-600">
+									<BookOpen className="h-4 w-4" />
+								</div>
+								<h2 className="text-[16px] font-extrabold text-[#111a44]">{title}</h2>
+							</div>
+							<div className="mt-4 flex items-center gap-3">
+								<span className="text-[11px] font-medium text-slate-500">65% complete</span>
+								<div className="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-100">
+									<div className="h-full w-[65%] rounded-full bg-blue-600" />
+								</div>
+							</div>
+						</div>
+
+						<div className="px-4 py-3">
+							{modules.map((m, i) => {
+								const open = i < 2;
+								const done = m.status === "completed";
+								return (
+									<div key={`${m.id}-${i}`} className="border-b border-slate-100 py-2 last:border-b-0">
+										<button className="flex w-full items-center justify-between py-1.5 text-left text-[13px] font-extrabold text-[#111a44]">
+											<span>{i + 1}. {m.title}</span>
+											<ChevronDown className={`h-4 w-4 text-slate-500 ${open ? "" : "-rotate-90"}`} />
+										</button>
+										{open && (
+											<ul className="mt-1 space-y-0.5 pb-1">
+												{m.lessons.map((lesson, j) => {
+													const completed = done || (i === 1 && j < 2);
+													return (
+														<li key={lesson} className="flex items-center gap-2 py-1.5 text-[12px] text-slate-600">
+															<span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-slate-100 text-[10px] font-semibold text-slate-400">{j + 1}</span>
+															<span className="min-w-0 flex-1 truncate">{lesson}</span>
+															{completed ? <CheckCircle2 className="h-4 w-4 text-emerald-500" /> : <span className="h-4 w-4 rounded-full border border-slate-300" />}
+														</li>
+													);
+												})}
+											</ul>
+										)}
+									</div>
+								);
+							})}
+						</div>
+
+						<div className="border-t border-slate-100 p-4">
+							<Link href={`/${lang}/masomo/progress`} className="flex h-9 items-center justify-between rounded-[6px] border border-slate-200 px-3 text-[12px] font-semibold text-slate-500 hover:bg-slate-50">
+								<span className="flex items-center gap-2"><BarChart3 className="h-4 w-4 text-slate-400" />View Progress</span>
+								<ChevronRight className="h-3.5 w-3.5" />
+							</Link>
+						</div>
+					</aside>
+
+					<section className="rounded-[10px] border border-slate-200 bg-white p-6 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+						<div className="mb-4">
+							<h1 className="text-[22px] font-extrabold text-[#111a44]">{title}</h1>
+							<p className="mt-1 text-[13px] text-slate-500">Your journey to becoming confident with Nuru.</p>
+						</div>
+
+						<div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+							<div className="flex items-center gap-5 rounded-[6px] border border-slate-200 bg-white px-3 py-2 text-[11.5px] text-slate-500">
+								<Legend icon={CheckCircle2} label="Completed" color="text-emerald-500" />
+								<Legend icon={CircleDot} label="In Progress" color="text-blue-500" />
+								<Legend icon={Lock} label="Locked" color="text-slate-400" />
+								<Legend icon={CircleDot} label="Next" color="text-amber-400" />
+							</div>
+							<button className="inline-flex h-9 items-center gap-2 rounded-[6px] border border-slate-200 bg-white px-4 text-[12px] font-semibold text-slate-600 hover:bg-slate-50">
+								<Expand className="h-3.5 w-3.5" /> Expand All
+							</button>
+						</div>
+
+						<div className="relative pl-2">
+							<div className="absolute top-11 bottom-0 left-8 w-px border-l border-dashed border-slate-300" />
+							<div className="space-y-6">
+								{modules.slice(0, 4).map((m, i) => {
+									const Icon = trackIcons[i];
+									const doneCount = i === 0 ? 3 : i === 1 ? 2 : 0;
+									return (
+										<div key={`${m.id}-track-${i}`} className="relative flex gap-5">
+											<div className={`relative z-10 flex h-[48px] w-[48px] shrink-0 items-center justify-center rounded-full border-4 shadow-lg ${trackTints[i]}`}>
+												<Icon className="h-5 w-5" />
+											</div>
+											<div className="flex-1 rounded-[10px] border border-slate-200 bg-white p-4 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+												<div className="mb-4 flex items-start justify-between gap-4">
+													<div>
+														<h3 className="text-[16px] font-extrabold text-[#111a44]">{i + 1}. {m.title}</h3>
+														<p className="mt-1 text-[12px] text-slate-500">{i === 0 ? "Karibu kwenye dunia ya Nuru. Anza safari yako hapa." : i === 1 ? "Jifunze misingi ya kuandika na kuona matokeo." : i === 2 ? "Hifadhi na tumia taarifa kwa kutumia variables." : "Aina za data na jinsi ya kuzitumia."}</p>
+													</div>
+													<div className="flex items-center gap-3">
+														<span className="text-[12px] font-medium text-slate-500">{doneCount} / {m.lessons.length} lessons</span>
+														<StatusBadge status={m.status} />
+													</div>
+												</div>
+												<div className="flex flex-wrap items-center gap-4">
+													{m.lessons.map((lesson, j) => {
+														const locked = m.status === "locked";
+														const active = i === 1 && j === 1;
+														const complete = m.status === "completed" || (i === 1 && j === 0);
+														return (
+															<Link key={lesson} href={locked ? "#" : nextHref} className={`relative flex h-[54px] min-w-[128px] max-w-[160px] items-center gap-2 rounded-[7px] border px-3 text-[10.5px] font-semibold ${active ? "border-blue-500 bg-white text-[#111a44] shadow-[0_0_0_2px_rgba(37,99,235,0.1)]" : locked ? "border-slate-200 bg-white text-slate-400" : "border-slate-200 bg-white text-slate-600"}`}>
+																{complete ? <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" /> : locked ? <Lock className="h-3.5 w-3.5 shrink-0 text-slate-400" /> : <CircleDot className="h-4 w-4 shrink-0 text-blue-500" />}
+																<span className="line-clamp-2">{i + 1}.{j + 1} {lesson}</span>
+																{j < m.lessons.length - 1 && !locked && <span className="absolute top-1/2 -right-4 h-px w-4 bg-emerald-300" />}
+															</Link>
+														);
+													})}
+												</div>
+											</div>
+										</div>
+									);
+								})}
+							</div>
+						</div>
+					</section>
+
+					<aside className="space-y-4">
+						<div className="rounded-[10px] border border-slate-200 bg-white p-5 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+							<h3 className="mb-3 text-[14px] font-extrabold text-[#111a44]">Your Progress</h3>
+							<div className="flex items-center gap-5">
+								<ProgressRing pct={65} />
+								<div className="space-y-3 text-[11px] text-slate-500">
+									<Metric icon={CheckCircle2} value="13" label="Lessons Completed" color="text-emerald-500" />
+									<Metric icon={Circle} value="20" label="Total Lessons" color="text-blue-500" />
+									<div><span className="font-bold text-[#111a44]">--</span> <span className="font-bold text-[#111a44]">~ 2h 15m</span><br /><span>Estimated Time Remaining</span></div>
+								</div>
+							</div>
+							<div className="mt-4 flex items-center gap-3 rounded-[8px] bg-blue-50/70 px-3 py-3">
+								<Sparkles className="h-5 w-5 text-amber-400" />
+								<p className="text-[11.5px] text-slate-500"><span className="font-extrabold text-[#111a44]">Great progress, David!</span><br />Keep going — you're building real skills.</p>
+							</div>
+						</div>
+
+						<div className="rounded-[10px] border border-slate-200 bg-white p-5 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+							<h3 className="mb-4 text-[14px] font-extrabold text-[#111a44]">Next Up</h3>
+							<div className="rounded-[8px] border border-slate-200 p-3">
+								<div className="text-[12.5px] font-extrabold text-[#111a44]">2.2 Outputting Results (andika)</div>
+								<p className="mt-1 text-[11px] text-slate-500">Jifunze kutumia <span className="font-mono">andika()</span> kuonyesha matokeo.</p>
+								<Link href={nextHref} className="mt-3 flex h-9 items-center justify-center gap-2 rounded-[5px] bg-blue-600 text-[12px] font-semibold text-white hover:bg-blue-700"><Play className="h-3.5 w-3.5 fill-current" />Continue Lesson</Link>
+								<div className="mt-3 flex items-center gap-1.5 text-[11px] font-medium text-slate-500"><Clock className="h-3.5 w-3.5" />Estimated time: ~10 min</div>
+							</div>
+						</div>
+
+						<div className="rounded-[10px] border border-slate-200 bg-white p-5 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+							<h3 className="mb-4 text-[14px] font-extrabold text-[#111a44]">Journey Summary</h3>
+							<ul className="space-y-2.5">
+								{modules.map((m, i) => <li key={m.title} className="flex items-center justify-between text-[12px]"><span className="text-slate-600">{i + 1}. {m.title}</span><span className="flex items-center gap-2 font-semibold text-slate-500">{i === 0 ? "3 / 3" : i === 1 ? "2 / 5" : "0 / 4"}{m.status === "completed" ? <CheckCircle2 className="h-4 w-4 text-emerald-500" /> : m.status === "in-progress" ? <CircleDot className="h-4 w-4 text-blue-500" /> : <Lock className="h-3.5 w-3.5 text-slate-300" />}</span></li>)}
+							</ul>
+							<Link href={`/${lang}/masomo/progress`} className="mt-5 flex h-10 items-center justify-between rounded-[6px] border border-slate-200 px-4 text-[12px] font-semibold text-slate-600 hover:bg-slate-50"><span className="flex items-center gap-2"><BarChart3 className="h-4 w-4 text-slate-400" />View Detailed Progress</span><ChevronRight className="h-3.5 w-3.5" /></Link>
+						</div>
+					</aside>
+				</div>
+			</div>
+		</main>
+	);
+}
+
+function Legend({ icon: Icon, label, color }: { icon: any; label: string; color: string }) {
+	return <span className="inline-flex items-center gap-1.5"><Icon className={`h-3.5 w-3.5 ${color}`} />{label}</span>;
+}
+
+function StatusBadge({ status }: { status: Status }) {
+	if (status === "completed") return <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-600">Completed</span>;
+	if (status === "in-progress") return <span className="rounded-full bg-blue-50 px-2.5 py-1 text-[11px] font-semibold text-blue-600">In Progress</span>;
+	return <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-500">Locked</span>;
+}
+
+function Metric({ icon: Icon, value, label, color }: { icon: any; value: string; label: string; color: string }) {
+	return <div className="flex items-center gap-2"><Icon className={`h-4 w-4 ${color}`} /><div><span className="text-[16px] font-extrabold text-[#111a44]">{value}</span><br /><span>{label}</span></div></div>;
+}
+
+function ProgressRing({ pct }: { pct: number }) {
+	const r = 42;
+	const c = 2 * Math.PI * r;
+	const off = c - (pct / 100) * c;
+	return (
+		<div className="relative h-[118px] w-[118px] shrink-0">
+			<svg className="h-full w-full -rotate-90" viewBox="0 0 108 108">
+				<circle cx="54" cy="54" r={r} stroke="rgb(226 232 240)" strokeWidth="8" fill="none" />
+				<circle cx="54" cy="54" r={r} stroke="rgb(37 99 235)" strokeWidth="8" fill="none" strokeLinecap="round" strokeDasharray={c} strokeDashoffset={off} />
+			</svg>
+			<div className="absolute inset-0 flex flex-col items-center justify-center">
+				<span className="text-[24px] font-extrabold text-[#111a44]">{pct}%</span>
+				<span className="text-[11px] font-medium text-slate-500">Overall</span>
+			</div>
+		</div>
+	);
+}

--- a/apps/playground/app/(main)/[lang]/masomo/progress/page.tsx
+++ b/apps/playground/app/(main)/[lang]/masomo/progress/page.tsx
@@ -1,0 +1,22 @@
+import { getAllModulesWithLessons } from "@/lib/lessons.server";
+import { getDictionary, Locale } from "@/app/(main)/[lang]/dictionaries";
+import { ProgressDashboardClient } from "./progress-client";
+
+export const dynamic = "force-dynamic";
+
+export default async function ProgressPage({
+	params,
+}: {
+	params: Promise<{ lang: string }>;
+}) {
+	const { lang } = await params;
+	const modules = await getAllModulesWithLessons();
+	const dict = await getDictionary(lang as Locale);
+	return (
+		<ProgressDashboardClient
+			modules={modules}
+			lang={lang as "en" | "sw"}
+			dict={dict}
+		/>
+	);
+}

--- a/apps/playground/app/(main)/[lang]/masomo/progress/progress-client.tsx
+++ b/apps/playground/app/(main)/[lang]/masomo/progress/progress-client.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+	Trophy,
+	Flame,
+	Target,
+	Clock,
+	TrendingUp,
+	CheckCircle2,
+	Sparkles,
+	ArrowRight,
+	Activity as ActivityIcon,
+} from "lucide-react";
+import type { Module } from "@/types/playground";
+import {
+	getActivity,
+	getBadges,
+	getPracticeWeek,
+	getRuns,
+	getStreak,
+	computeBadges,
+	type PlaygroundActivity,
+	type EarnedBadge,
+	type PracticeSession,
+} from "@/lib/playground-storage";
+
+interface Props {
+	modules: Module[];
+	lang: "en" | "sw";
+	dict: any;
+}
+
+export function ProgressDashboardClient({ modules, lang }: Props) {
+	const [activity, setActivity] = useState<PlaygroundActivity[]>([]);
+	const [badges, setBadges] = useState<EarnedBadge[]>([]);
+	const [week, setWeek] = useState<PracticeSession[]>([]);
+	const [streak, setStreak] = useState(0);
+	const [runs, setRuns] = useState<number>(0);
+
+	// Aggregate completed lessons across modules from per-module localStorage
+	const completed = useMemo(() => {
+		if (typeof window === "undefined") return 0;
+		let total = 0;
+		for (const m of modules) {
+			try {
+				const raw = window.localStorage.getItem(`nuru-completed-${m.id}`);
+				if (raw) total += (JSON.parse(raw) as number[]).length;
+			} catch {}
+		}
+		return total;
+	}, [modules]);
+
+	const totalLessons = modules.reduce((n, m) => n + m.lessons.length, 0);
+	const pct = totalLessons ? Math.round((completed / totalLessons) * 100) : 0;
+
+	useEffect(() => {
+		setActivity(getActivity(10));
+		setWeek(getPracticeWeek());
+		setStreak(getStreak());
+		const r = getRuns();
+		setRuns(r.length);
+		const passedSuites = r.filter((x) => x.success).length;
+		setBadges(
+			computeBadges({
+				completedCount: completed,
+				streak: getStreak(),
+				passedSuites,
+			}),
+		);
+	}, [completed]);
+
+	// Recommended next: first incomplete lesson
+	const nextLesson = useMemo(() => {
+		for (const m of modules) {
+			let completedIdx: number[] = [];
+			try {
+				if (typeof window !== "undefined") {
+					const raw = window.localStorage.getItem(`nuru-completed-${m.id}`);
+					if (raw) completedIdx = JSON.parse(raw);
+				}
+			} catch {}
+			const idx = m.lessons.findIndex((_, i) => !completedIdx.includes(i));
+			if (idx >= 0) return { module: m, lesson: m.lessons[idx] };
+		}
+		return null;
+	}, [modules]);
+
+	const maxMinutes = Math.max(1, ...week.map((d) => d.minutes));
+
+	return (
+		<main className="flex-1 overflow-auto bg-slate-50 p-6 md:p-10">
+			<div className="mx-auto max-w-6xl">
+				<div className="mb-8 flex items-end justify-between gap-4">
+					<div>
+						<h1 className="text-3xl font-bold tracking-tight text-slate-900">
+							My Progress
+						</h1>
+						<p className="mt-1 text-sm text-slate-600">
+							Your learning journey across Nuru Playground
+						</p>
+					</div>
+					{nextLesson && (
+						<Link
+							href={`/${lang}/anza/${nextLesson.module.slug}/${nextLesson.lesson.slug}`}
+							className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-700"
+						>
+							Continue Learning
+							<ArrowRight className="h-4 w-4" />
+						</Link>
+					)}
+				</div>
+
+				{/* Metrics */}
+				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+					<MetricCard
+						icon={<CheckCircle2 className="h-5 w-5 text-emerald-500" />}
+						label="Lessons completed"
+						value={`${completed}/${totalLessons}`}
+						sub={`${pct}% overall`}
+					/>
+					<MetricCard
+						icon={<Flame className="h-5 w-5 text-orange-500" />}
+						label="Current streak"
+						value={`${streak} day${streak === 1 ? "" : "s"}`}
+						sub={streak > 0 ? "Keep it going!" : "Run code today to start"}
+					/>
+					<MetricCard
+						icon={<Target className="h-5 w-5 text-blue-500" />}
+						label="Total runs"
+						value={`${runs}`}
+						sub="Code executions"
+					/>
+					<MetricCard
+						icon={<Trophy className="h-5 w-5 text-amber-500" />}
+						label="Badges earned"
+						value={`${badges.length}`}
+						sub={badges.length ? "Nice work" : "Earn your first"}
+					/>
+				</div>
+
+				<div className="mt-6 grid gap-4 md:grid-cols-3">
+					{/* Weekly practice */}
+					<div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm md:col-span-2">
+						<div className="mb-4 flex items-center justify-between">
+							<div>
+								<h2 className="text-base font-semibold text-slate-900">
+									Weekly Practice
+								</h2>
+								<p className="text-xs text-slate-500">Last 7 days</p>
+							</div>
+							<TrendingUp className="h-5 w-5 text-blue-500" />
+						</div>
+						<div className="flex h-40 items-end gap-3">
+							{week.map((d) => {
+								const h = Math.round((d.minutes / maxMinutes) * 100);
+								return (
+									<div key={d.date} className="flex flex-1 flex-col items-center gap-2">
+										<div
+											className="w-full rounded-t-lg bg-gradient-to-t from-blue-500 to-blue-400"
+											style={{ height: `${Math.max(4, h)}%` }}
+											title={`${d.minutes} min`}
+										/>
+										<div className="text-[10.5px] text-slate-500">
+											{new Date(d.date).toLocaleDateString(undefined, {
+												weekday: "short",
+											})}
+										</div>
+									</div>
+								);
+							})}
+						</div>
+					</div>
+
+					{/* Badges */}
+					<div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+						<div className="mb-4 flex items-center justify-between">
+							<h2 className="text-base font-semibold text-slate-900">
+								Badges Earned
+							</h2>
+							<Trophy className="h-5 w-5 text-amber-500" />
+						</div>
+						{badges.length === 0 ? (
+							<p className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-center text-xs text-slate-500">
+								Complete lessons and pass tests to earn badges.
+							</p>
+						) : (
+							<ul className="space-y-2.5">
+								{badges.map((b) => (
+									<li
+										key={b.id}
+										className="flex items-center gap-3 rounded-xl border border-amber-100 bg-amber-50/60 px-3 py-2.5"
+									>
+										<div className="flex h-9 w-9 items-center justify-center rounded-lg bg-amber-100">
+											<Sparkles className="h-4 w-4 text-amber-600" />
+										</div>
+										<div className="min-w-0">
+											<div className="truncate text-[13px] font-semibold text-slate-900">
+												{b.title}
+											</div>
+											<div className="truncate text-[11px] text-slate-500">
+												{b.description}
+											</div>
+										</div>
+									</li>
+								))}
+							</ul>
+						)}
+					</div>
+				</div>
+
+				<div className="mt-6 grid gap-4 md:grid-cols-3">
+					{/* Course progress */}
+					<div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm md:col-span-2">
+						<h2 className="mb-4 text-base font-semibold text-slate-900">
+							Current Course Progress
+						</h2>
+						<ul className="space-y-3">
+							{modules.map((m) => {
+								let count = 0;
+								try {
+									if (typeof window !== "undefined") {
+										const raw = window.localStorage.getItem(
+											`nuru-completed-${m.id}`,
+										);
+										if (raw) count = (JSON.parse(raw) as number[]).length;
+									}
+								} catch {}
+								const p = Math.round((count / m.lessons.length) * 100);
+								return (
+									<li
+										key={m.id}
+										className="rounded-xl border border-slate-200 bg-white px-4 py-3"
+									>
+										<div className="mb-1.5 flex items-center justify-between">
+											<Link
+												href={`/${lang}/anza/${m.slug}`}
+												className="truncate text-[13.5px] font-semibold text-slate-800 hover:text-blue-600"
+											>
+												{m.title[lang] || m.title.sw}
+											</Link>
+											<span className="text-[11.5px] font-medium text-slate-500">
+												{count} / {m.lessons.length}
+											</span>
+										</div>
+										<div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-100">
+											<div
+												className="h-full rounded-full bg-blue-600 transition-all"
+												style={{ width: `${p}%` }}
+											/>
+										</div>
+									</li>
+								);
+							})}
+						</ul>
+					</div>
+
+					{/* Recent activity */}
+					<div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+						<div className="mb-4 flex items-center justify-between">
+							<h2 className="text-base font-semibold text-slate-900">
+								Recent Activity
+							</h2>
+							<ActivityIcon className="h-5 w-5 text-blue-500" />
+						</div>
+						{activity.length === 0 ? (
+							<p className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-center text-xs text-slate-500">
+								Run some code to populate your activity.
+							</p>
+						) : (
+							<ul className="space-y-2.5">
+								{activity.map((a) => (
+									<li key={a.id} className="flex items-start gap-2.5">
+										<div className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500" />
+										<div className="min-w-0 flex-1">
+											<div className="truncate text-[12.5px] font-medium text-slate-800">
+												{a.title}
+											</div>
+											<div className="text-[11px] text-slate-500">
+												{new Date(a.createdAt).toLocaleString()}
+											</div>
+										</div>
+									</li>
+								))}
+							</ul>
+						)}
+					</div>
+				</div>
+
+				{/* Motivation banner */}
+				<div className="mt-6 overflow-hidden rounded-2xl border border-blue-200 bg-gradient-to-r from-blue-50 to-indigo-50 px-6 py-5">
+					<div className="flex items-center gap-4">
+						<div className="flex h-12 w-12 items-center justify-center rounded-xl bg-white shadow-sm">
+							<Clock className="h-5 w-5 text-blue-600" />
+						</div>
+						<div className="flex-1">
+							<h3 className="text-[15px] font-semibold text-slate-900">
+								Keep your momentum going
+							</h3>
+							<p className="text-[12.5px] text-slate-600">
+								A few minutes a day adds up fast. Every run counts.
+							</p>
+						</div>
+						{nextLesson && (
+							<Link
+								href={`/${lang}/anza/${nextLesson.module.slug}/${nextLesson.lesson.slug}`}
+								className="inline-flex items-center gap-2 rounded-xl border border-blue-200 bg-white px-3.5 py-2 text-[12.5px] font-semibold text-blue-700 hover:bg-blue-50"
+							>
+								Resume lesson
+								<ArrowRight className="h-3.5 w-3.5" />
+							</Link>
+						)}
+					</div>
+				</div>
+			</div>
+		</main>
+	);
+}
+
+function MetricCard({
+	icon,
+	label,
+	value,
+	sub,
+}: {
+	icon: React.ReactNode;
+	label: string;
+	value: string;
+	sub?: string;
+}) {
+	return (
+		<div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+			<div className="mb-2 flex items-center justify-between">
+				<span className="text-[11.5px] font-medium uppercase tracking-wider text-slate-500">
+					{label}
+				</span>
+				{icon}
+			</div>
+			<div className="text-2xl font-bold tracking-tight text-slate-900">
+				{value}
+			</div>
+			{sub && <div className="mt-0.5 text-[11.5px] text-slate-500">{sub}</div>}
+		</div>
+	);
+}

--- a/apps/playground/app/globals.css
+++ b/apps/playground/app/globals.css
@@ -8,8 +8,9 @@
 
 @theme inline {
 	--font-*: initial;
-	/* --font-sans: var(--font-jetbrains-mono), JetBrains Mono, monospace; */
-	--font-mono: var(--font-jetbrains-mono), JetBrains Mono, monospace;
+	--font-sans: var(--font-inter), Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+	--font-display: var(--font-jakarta), "Plus Jakarta Sans", var(--font-inter), Inter, ui-sans-serif, system-ui, sans-serif;
+	--font-mono: var(--font-jetbrains-mono), "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 	--font-noto-rashi: var(--font-noto-rashi);
 
 	--color-background: var(--background);
@@ -100,6 +101,22 @@
 
 @utility text-balance {
 	text-wrap: balance;
+}
+
+@layer base {
+	html, body {
+		font-family: var(--font-sans);
+		font-feature-settings: "cv11", "ss01", "ss03";
+		-webkit-font-smoothing: antialiased;
+		text-rendering: optimizeLegibility;
+	}
+	h1, h2, h3, h4, h5, h6 {
+		font-family: var(--font-display);
+		letter-spacing: -0.015em;
+	}
+	code, pre, kbd, samp, .font-mono {
+		font-family: var(--font-mono);
+	}
 }
 
 :root {

--- a/apps/playground/app/globals.css
+++ b/apps/playground/app/globals.css
@@ -182,6 +182,56 @@
 	}
 }
 
+/* Hide scrollbars globally but keep scrollability */
+
+html,
+body {
+	overflow: hidden;
+}
+
+*,
+*::before,
+*::after {
+	scrollbar-width: none !important;
+	-ms-overflow-style: none !important;
+}
+
+*::-webkit-scrollbar {
+	width: 0 !important;
+	height: 0 !important;
+	display: none !important;
+	background: transparent !important;
+}
+
+.scrollbar-none,
+.scrollbar-none * {
+	scrollbar-width: none !important;
+	-ms-overflow-style: none !important;
+}
+
+.scrollbar-none::-webkit-scrollbar,
+.scrollbar-none *::-webkit-scrollbar {
+	width: 0 !important;
+	height: 0 !important;
+	display: none !important;
+	background: transparent !important;
+}
+
+[data-radix-scroll-area-scrollbar] {
+	width: 0 !important;
+	height: 0 !important;
+	min-width: 0 !important;
+	min-height: 0 !important;
+	overflow: hidden !important;
+	visibility: hidden !important;
+	opacity: 0 !important;
+	pointer-events: none !important;
+}
+
+[data-radix-scroll-area-corner] {
+	display: none !important;
+}
+
 @keyframes sprout-glow {
 	0% {
 		opacity: 0.5;

--- a/apps/playground/app/layout.tsx
+++ b/apps/playground/app/layout.tsx
@@ -13,8 +13,20 @@ export const viewport: Viewport = {
 
 import "./globals.css";
 
-import { JetBrains_Mono, Noto_Rashi_Hebrew } from "next/font/google";
+import { Inter, Plus_Jakarta_Sans, JetBrains_Mono, Noto_Rashi_Hebrew } from "next/font/google";
 
+const inter = Inter({
+	subsets: ["latin"],
+	display: "swap",
+	weight: ["400", "500", "600", "700"],
+	variable: "--font-inter",
+});
+const jakarta = Plus_Jakarta_Sans({
+	subsets: ["latin"],
+	display: "swap",
+	weight: ["500", "600", "700", "800"],
+	variable: "--font-jakarta",
+});
 const jetbrainsMono = JetBrains_Mono({
 	subsets: ["latin"],
 	display: "swap",
@@ -47,7 +59,7 @@ export default function RootLayout({
 		<html
 			lang="en"
 			suppressHydrationWarning
-			className={cn(jetbrainsMono.variable, NotoRashi.variable)}
+			className={cn(inter.variable, jakarta.variable, jetbrainsMono.variable, NotoRashi.variable)}
 		>
 			<head>
 				<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
@@ -61,7 +73,8 @@ export default function RootLayout({
 				<meta name="theme-color" content="#00b4d8" />
 				<link rel="manifest" href="/manifest.json" />
 			</head>
-			<body className={"flex h-dvh flex-col"}>
+			<body className={"flex h-dvh flex-col font-sans antialiased"}>
+
 				<Suspense>
 					<CustomThemeProvider>{children}</CustomThemeProvider>
 				</Suspense>

--- a/apps/playground/components/header.tsx
+++ b/apps/playground/components/header.tsx
@@ -1,23 +1,17 @@
 "use client";
 
-import React from "react";
-import { usePathname, useRouter } from "next/navigation";
+import React, { useContext } from "react";
+import { usePathname } from "next/navigation";
 import Link from "next/link";
 
 import UserMenu from "@/components/UserMenu";
 
 import { LessonsDrawer } from "@/components/lessons-drawer";
 
-import {AppLogo} from "@nuru/ui/components/app-logo"
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@nuru/ui/components/dropdown-menu";
-
-import { BookOpen, ChevronDown, Languages } from "lucide-react";
+import { AppLogo } from "@nuru/ui/components/app-logo";
+import { ChevronDown } from "lucide-react";
 import { Dictionary } from "@/app/(main)/[lang]/dictionaries";
+import { AuthContext } from "@/components/providers/auth-provider";
 
 interface SiteHeaderProps {
 	modules?: { id: string; slug: string; title: { sw: string; en: string } }[];
@@ -27,147 +21,68 @@ interface SiteHeaderProps {
 
 export function SiteHeader({ modules = [], lang, dict }: SiteHeaderProps) {
 	const pathname = usePathname();
-	const router = useRouter();
+	const { claims } = useContext(AuthContext);
+	const firstName = claims?.name?.split(" ")?.[0] || claims?.username || "";
 
 	const navItems = [
 		{
-			label: dict.header.home,
+			label: "Home",
 			href: `/${lang}`,
 			active: pathname === `/${lang}`,
 		},
 		{
-			label: dict.header.anza,
+			label: "Playground",
 			href: `/${lang}/anza`,
 			active: pathname.startsWith(`/${lang}/anza`),
 		},
 	];
 
-	const toggleLanguage = () => {
-		const newLang = lang === "sw" ? "en" : "sw";
-		// Replace the language segment in the URL
-		const segments = pathname.split("/");
-		if (segments[1] === lang) {
-			segments[1] = newLang;
-			router.push(segments.join("/"));
-		} else {
-			router.push(`/${newLang}`);
-		}
-	};
-
 	return (
-		<>
-			{/* Main Header Container */}
-			<header className="border-border/50 bg-background/80 sticky top-0 right-0 left-0 z-40 border-b shadow-xs backdrop-blur-md">
-				<div className="flex h-14 items-center justify-between px-4 md:px-8">
-					{/* Logo Section (Left on Mobile & Desktop) */}
-					<div className="flex items-center gap-2 md:order-1">
+		<header className="sticky top-0 right-0 left-0 z-40 border-b border-slate-200 bg-white/95 shadow-[0_1px_0_rgba(15,23,42,0.02)] backdrop-blur-md">
+			<div className="mx-auto flex h-16 max-w-[1280px] items-center justify-between gap-4 px-5">
+				<Link
+					href={`/${lang}`}
+					title="Home"
+					className="group flex shrink-0 items-center gap-2.5"
+				>
+					<AppLogo size={32} className="rounded-lg" />
+					<span className="text-[20px] font-bold tracking-tight text-slate-900">Nuru</span>
+				</Link>
+
+				<nav className="hidden h-full min-w-0 flex-1 items-center justify-center gap-8 md:flex">
+					{navItems.map((item) => (
 						<Link
-							href={`/${lang}`}
-							className="group flex items-center gap-3 transition-opacity hover:opacity-90"
+							key={item.href}
+							href={item.href}
+							className={`relative flex h-full shrink-0 items-center whitespace-nowrap text-[14px] font-semibold transition-colors ${
+								item.active ? "text-slate-950" : "text-slate-500 hover:text-slate-800"
+							}`}
 						>
-							<div className="relative">
-								<div className="absolute inset-0 rounded-full bg-yellow-500/20 opacity-0 blur-lg transition-opacity duration-500 group-hover:opacity-100" />
-								<AppLogo
-									size={32}
-									className="relative z-10 group-hover:animate-[logo-hover_3s_ease-in-out_infinite]"
-								/>
-							</div>
-
-							<span className="hidden text-lg font-bold tracking-tight md:block">
-								Nuru
-							</span>
+							{item.label}
+							{item.active && (
+								<span className="absolute right-0 bottom-0 left-0 h-0.5 rounded-full bg-blue-600" />
+							)}
 						</Link>
+					))}
+				</nav>
+
+
+				<div className="flex shrink-0 items-center gap-5">
+					<div className="md:hidden">
+						<LessonsDrawer modules={modules} lang={lang} dict={dict} />
 					</div>
-
-					{/* Desktop Center Navigation */}
-					<nav className="absolute left-1/2 hidden -translate-x-1/2 items-center gap-2 md:order-2 md:flex">
-						{navItems.map((item) => (
-							<Link
-								key={item.href}
-								href={item.href}
-								className={`rounded-full px-4 py-2 text-sm font-medium transition-all ${
-									item.active
-										? "bg-foreground text-background shadow-xs"
-										: "text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-								}`}
-							>
-								{item.label}
-							</Link>
-						))}
-
-						<DropdownMenu>
-							<DropdownMenuTrigger asChild>
-								<button className="text-muted-foreground hover:bg-muted/50 hover:text-foreground flex items-center gap-1 rounded-full px-4 py-2 text-sm font-medium transition-all">
-									{dict.header.masomo}
-									<ChevronDown className="h-3 w-3 opacity-50" />
-								</button>
-							</DropdownMenuTrigger>
-							<DropdownMenuContent
-								align="center"
-								className="w-56 rounded-xl p-2"
-							>
-								<DropdownMenuItem
-									asChild
-									className="bg-muted/50 mb-1 rounded-lg"
-								>
-									<Link
-										href={`/${lang}/masomo`}
-										className="text-primary flex items-center gap-2 py-2 font-bold"
-									>
-										<BookOpen className="h-4 w-4" />
-										<span>{dict.map.title}</span>
-									</Link>
-								</DropdownMenuItem>
-								{modules.map((module) => (
-									<DropdownMenuItem
-										key={module.id}
-										asChild
-										className="rounded-lg"
-									>
-										<Link
-											href={
-												module.slug === "misingi-ya-nuru"
-													? `/${lang}/anza`
-													: `/${lang}/anza/${module.slug}`
-											}
-											className="flex items-center gap-2 py-2"
-										>
-											<div className="flex flex-col">
-												<span className="text-sm font-medium">
-													{module.title[lang] || module.title.sw}
-												</span>
-												<span className="text-muted-foreground text-[10px]">
-													{lang === "sw" ? module.title.en : module.title.sw}
-												</span>
-											</div>
-										</Link>
-									</DropdownMenuItem>
-								))}
-							</DropdownMenuContent>
-						</DropdownMenu>
-					</nav>
-
-					{/* Right Section: User Menu & Mobile Menu */}
-					<div className="flex items-center gap-2 md:order-3">
-						{/* Language Switcher */}
-						<button
-							onClick={toggleLanguage}
-							className="bg-background/50 text-muted-foreground hover:bg-muted/50 hover:text-foreground flex items-center gap-2 rounded px-3 py-1.5 text-sm font-medium transition-all"
-						>
-							<Languages className="size-4" />
-							<p className="hidden md:block">
-								{lang === "sw" ? "English" : "Kiswahili"}
-							</p>
-						</button>
-
-						{/* Mobile Lessons Drawer Trigger */}
-						<div className="md:hidden">
-							<LessonsDrawer modules={modules} lang={lang} dict={dict} />
-						</div>
+					<div className="flex items-center gap-1.5">
 						<UserMenu />
+						{firstName && (
+							<>
+								<span className="hidden text-[13px] font-semibold text-slate-600 md:inline">{firstName}</span>
+								<ChevronDown className="hidden h-3.5 w-3.5 text-slate-400 md:block" />
+							</>
+						)}
 					</div>
 				</div>
-			</header>
-		</>
+
+			</div>
+		</header>
 	);
 }

--- a/apps/playground/components/playground/code-panel.tsx
+++ b/apps/playground/components/playground/code-panel.tsx
@@ -68,7 +68,7 @@ export function CodePanel({
 	const isMaximized = activeMaximizedPanel === "editor";
 	const isDev = process.env.NODE_ENV === "development";
 
-	const fileExt = module?.executor === "python" ? "py" : "nuru";
+	const fileExt = module?.executor === "python" ? "py" : "nr";
 
 	const editor = (
 		<div className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-slate-800 bg-[#0b1220] shadow-sm">

--- a/apps/playground/components/playground/code-panel.tsx
+++ b/apps/playground/components/playground/code-panel.tsx
@@ -1,14 +1,10 @@
 "use client";
 import React from "react";
-import { Play, RotateCcw, Eye, HelpCircle, ArrowRight } from "lucide-react";
+import { Play, RotateCcw, Maximize2, MoreVertical, AlignLeft, CircleDot, ArrowRight, Eye, HelpCircle } from "lucide-react";
 import { CodeEditor } from "@nuru/ui/components/code-editor";
 import { OutputPanel } from "./output-panel";
 import { Button } from "@nuru/ui/components/button";
 import { cn } from "@nuru/ui/lib/utils";
-import { Tooltip } from "@nuru/ui/components/tooltip";
-import { TooltipContent } from "@nuru/ui/components/tooltip";
-import { TooltipProvider } from "@nuru/ui/components/tooltip";
-import { TooltipTrigger } from "@nuru/ui/components/tooltip";
 import {
 	ResizableHandle,
 	ResizablePanel,
@@ -21,21 +17,22 @@ interface CodePanelProps {
 	onRun?: () => void;
 	isMobile?: boolean;
 	mobileExtra?: React.ReactNode;
+	/** When true, render only the editor card (no stacked output). Used by the desktop 3-column layout. */
+	editorOnly?: boolean;
 }
 
 export function CodePanel({
 	onRun: onRunProp,
 	isMobile,
-	mobileExtra,
+	editorOnly,
 }: CodePanelProps) {
 	const {
 		module,
-		panels: { activeMaximizedPanel },
-		state: { code, output },
+		panels: { activeMaximizedPanel, maximizePanel, restorePanels },
+		state: { code },
 		actions: {
 			onCodeChange,
 			onRun: onRunAction,
-			onSubmit,
 			onShowSolution,
 			onShowHint,
 			onReset,
@@ -68,128 +65,160 @@ export function CodePanel({
 	}, [activeMaximizedPanel]);
 
 	const onRun = onRunProp || onRunAction;
-
+	const isMaximized = activeMaximizedPanel === "editor";
 	const isDev = process.env.NODE_ENV === "development";
 
-	const actions = (isMobileLayout: boolean) => (
-		<TooltipProvider>
-			<div className={cn(
-				"flex items-center gap-1.5 transition-all",
-				!isMobileLayout && "rounded-xl border border-border/50 bg-background/60 p-1.5 backdrop-blur-md shadow-lg"
-			)}>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<Button
-							variant="ghost"
-							size="icon"
-							onClick={onReset}
-							className="h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-						>
-							<RotateCcw className="h-4 w-4" />
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent side="top" className="text-[10px] uppercase font-bold tracking-wider">
-						{labels.reset}
-					</TooltipContent>
-				</Tooltip>
+	const fileExt = module?.executor === "python" ? "py" : "nuru";
 
-				{onShowHint && (
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<Button
-							variant="ghost"
-							size="icon"
+	const editor = (
+		<div className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-slate-800 bg-[#0b1220] shadow-sm">
+			{/* File tab header */}
+			<div className="flex h-11 shrink-0 items-center justify-between border-b border-slate-800/80 bg-[#0b1220] pl-4 pr-2">
+				<div className="flex items-center gap-2">
+					<div className="flex items-center gap-2 border-b-2 border-blue-500 px-1 pb-[10px] pt-[10px] -mb-px">
+						<span className="text-[12.5px] font-medium text-slate-200">
+							main.{fileExt}
+						</span>
+						<span className="block h-1.5 w-1.5 rounded-full bg-blue-400" />
+					</div>
+				</div>
+				<div className="flex items-center gap-1">
+					<button
+						onClick={() =>
+							isMaximized ? restorePanels() : maximizePanel("editor")
+						}
+						aria-label="Maximize editor"
+						className="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-200"
+					>
+						<Maximize2 className="h-4 w-4" />
+					</button>
+					<button
+						aria-label="More"
+						className="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-200"
+					>
+						<MoreVertical className="h-4 w-4" />
+					</button>
+				</div>
+			</div>
+
+			{/* Editor */}
+			<div className="relative min-h-0 flex-1">
+				<CodeEditor
+					code={code}
+					onChange={onCodeChange}
+					theme="dark"
+					extensions={extensions}
+				/>
+			</div>
+
+			{/* Action bar */}
+			<div className="flex h-12 shrink-0 items-center justify-between border-t border-slate-800/80 bg-[#0b1220] px-3">
+				<div className="flex items-center gap-1">
+					<button
+						type="button"
+						onClick={() => {
+							// Basic format: convert tabs to 2 spaces, strip trailing whitespace,
+							// collapse 3+ blank lines, ensure trailing newline.
+							const formatted = code
+								.replace(/\t/g, "  ")
+								.split("\n")
+								.map((l) => l.replace(/\s+$/g, ""))
+								.join("\n")
+								.replace(/\n{3,}/g, "\n\n")
+								.replace(/\s*$/, "\n");
+							if (formatted !== code) onCodeChange(formatted);
+						}}
+						className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-[12px] text-slate-300 hover:bg-slate-800"
+					>
+						<AlignLeft className="h-3.5 w-3.5" />
+						<span>Format Code</span>
+						<span className="ml-1 rounded bg-slate-800 px-1.5 py-0.5 text-[10px] text-slate-400">
+							Ctrl+Shift+F
+						</span>
+					</button>
+				</div>
+				<div className="flex items-center gap-2">
+					{onShowHint && (
+						<button
 							onClick={onShowHint}
-							className="h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+							aria-label={labels.hint}
+							className="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-200"
 						>
 							<HelpCircle className="h-4 w-4" />
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent side="top" className="text-[10px] uppercase font-bold tracking-wider">
-						{labels.hint}
-					</TooltipContent>
-				</Tooltip>
-				)}
-
-				{isDev && onShowSolution && (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								variant="ghost"
-								size="icon"
-								onClick={onShowSolution}
-								className="h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-							>
-								<Eye className="h-4 w-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent side="top" className="text-[10px] uppercase font-bold tracking-wider">
-							{labels.showSolution}
-						</TooltipContent>
-					</Tooltip>
-				)}
-
-				<div className="mx-1 h-4 w-px bg-border/50" />
-
-				<Button
-					onClick={onRun}
-					size="sm"
-					className="h-8 bg-primary px-3 text-[11px] tracking-wider uppercase text-primary-foreground shadow-lg shadow-primary/20 hover:bg-primary/90 hover:scale-[1.02] active:scale-95 transition-all flex items-center gap-2"
-				>
-					<Play className="h-3 w-3 fill-current" />
-					{labels.run}
-				</Button>
-
-				{isCompleted && onNextAction && (
-					<>
-						<div className="mx-1 h-4 w-px bg-border/50" />
+						</button>
+					)}
+					{isDev && onShowSolution && (
+						<button
+							onClick={onShowSolution}
+							aria-label={labels.showSolution}
+							className="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-200"
+						>
+							<Eye className="h-4 w-4" />
+						</button>
+					)}
+					<button
+						onClick={onReset}
+						className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[12.5px] text-slate-300 hover:bg-slate-800"
+					>
+						<RotateCcw className="h-3.5 w-3.5" />
+						<span>{labels.reset}</span>
+					</button>
+					<Button
+						onClick={onRun}
+						size="sm"
+						className="h-8 gap-2 rounded-lg bg-blue-600 px-4 text-[12.5px] font-semibold text-white shadow-sm hover:bg-blue-700"
+					>
+						<Play className="h-3.5 w-3.5 fill-current" />
+						<span>{labels.run}</span>
+						<span className="ml-1 rounded bg-blue-700/60 px-1.5 py-0.5 text-[10px] font-medium text-blue-50">
+							Ctrl+Enter
+						</span>
+					</Button>
+					{isCompleted && onNextAction && (
 						<Button
 							onClick={onNextAction}
 							size="sm"
-							className="h-8 bg-green-600 px-3 text-[11px] tracking-wider uppercase text-white shadow-lg shadow-green-600/20 hover:bg-green-700 hover:scale-[1.02] active:scale-95 transition-all flex items-center gap-2 animate-pulse"
+							className="h-8 gap-1.5 rounded-lg bg-emerald-600 px-3 text-[12px] font-semibold text-white hover:bg-emerald-700"
 						>
 							{nextActionLabel}
-							<ArrowRight className="h-3 w-3" />
+							<ArrowRight className="h-3.5 w-3.5" />
 						</Button>
-					</>
-				)}
+					)}
+				</div>
 			</div>
-		</TooltipProvider>
+		</div>
 	);
 
-	// Mobile: editor with bottom toolbar (above terminal)
+	// Editor-only: parent renders OutputPanel separately
+	if (editorOnly) {
+		return <div className="h-full w-full">{editor}</div>;
+	}
+
+	// Mobile
 	if (isMobile) {
 		return (
-			<div className="bg-background relative flex h-full flex-col overflow-hidden text-sm">
-				<div className="flex-1 overflow-hidden">
-					<CodeEditor code={code} onChange={onCodeChange} theme={theme} extensions={extensions}/>
-				</div>
-				<div className="flex-none flex items-center justify-end p-2 border-t border-border bg-muted/5 backdrop-blur-sm z-10 shrink-0">
-					{actions(true)}
-				</div>
+			<div className="relative flex h-full flex-col overflow-hidden bg-slate-50 text-sm">
+				<div className="min-h-0 flex-1 p-2">{editor}</div>
 			</div>
 		);
 	}
 
-	// Desktop: editor with floating run button + output
+	// Fallback desktop: stacked editor + output (used when no module / no sidebar)
 	return (
-		<div className="bg-background flex h-full flex-col">
+		<div className="flex h-full flex-col bg-slate-50">
 			<ResizablePanelGroup direction="vertical" className="flex-1">
 				{activeMaximizedPanel !== "renderer" && (
 					<>
-						<ResizablePanel 
+						<ResizablePanel
 							ref={editorPanelRef}
-							defaultSize={60} 
+							defaultSize={60}
 							minSize={30}
 							collapsible
 							collapsedSize={0}
 						>
-							<div className="relative h-full">
-								<CodeEditor code={code} onChange={onCodeChange} theme={theme} extensions={extensions} />
-								<div className="absolute bottom-3 right-3 z-10">{actions(false)}</div>
-							</div>
+							<div className="h-full p-3 pb-2">{editor}</div>
 						</ResizablePanel>
-						<ResizableHandle withHandle />
+						<ResizableHandle />
 					</>
 				)}
 				<ResizablePanel
@@ -199,7 +228,9 @@ export function CodePanel({
 					collapsible
 					collapsedSize={0}
 				>
-					<OutputPanel showToolbar={false} />
+					<div className="h-full px-3 pb-3 pt-1">
+						<OutputPanel showToolbar={false} />
+					</div>
 				</ResizablePanel>
 			</ResizablePanelGroup>
 		</div>

--- a/apps/playground/components/playground/curriculum-sidebar.tsx
+++ b/apps/playground/components/playground/curriculum-sidebar.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { BookOpen, ChevronDown, CheckCircle2, CircleDot, Trophy } from "lucide-react";
+import { cn } from "@nuru/ui/lib/utils";
+import { ScrollArea } from "@/components/playground/scroll-area";
+import { usePlayground } from "./playground-context";
+import { Button } from "@nuru/ui/components/button";
+
+/**
+ * Left curriculum sidebar shown on desktop. Mirrors the uploaded mockups:
+ * - Module title card with progress bar
+ * - Expandable section list (currently we render a single section based on the active module)
+ * - Numbered lesson rows with active / completed states
+ * - "View Progress" CTA pinned to the bottom
+ */
+export function CurriculumSidebar() {
+	const {
+		module,
+		state: { currentLessonIndex = 0, completedLessonIndices },
+		actions: { onLessonChange },
+		lang,
+		labels,
+	} = usePlayground();
+
+	const [expanded, setExpanded] = useState(true);
+
+	if (!module) return null;
+
+	const total = module.lessons.length;
+	const completed = completedLessonIndices?.size ?? 0;
+	const pct = total === 0 ? 0 : Math.round((completed / total) * 100);
+
+	return (
+		<aside className="flex h-full w-full flex-col border-r border-slate-200 bg-white">
+			{/* Module header card */}
+			<div className="border-b border-slate-200 px-5 pt-5 pb-4">
+				<div className="flex items-center gap-2.5">
+					<div className="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+						<BookOpen className="h-4 w-4" />
+					</div>
+					<h2 className="truncate text-[15px] font-semibold text-slate-900">
+						{module.title[lang] || module.title.sw}
+					</h2>
+				</div>
+				<div className="mt-4">
+					<div className="mb-1.5 flex items-center justify-between text-[11px] text-slate-500">
+						<span>{pct}% complete</span>
+						<span className="font-medium">{completed}/{total}</span>
+					</div>
+					<div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-100">
+						<div
+							className="h-full rounded-full bg-blue-600 transition-all duration-500"
+							style={{ width: `${pct}%` }}
+						/>
+					</div>
+				</div>
+			</div>
+
+			{/* Lessons */}
+			<ScrollArea className="flex-1">
+				<div className="px-3 py-3">
+					<button
+						onClick={() => setExpanded((v) => !v)}
+						className="flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-[13px] font-semibold text-blue-700 hover:bg-slate-50"
+					>
+						<span className="truncate">
+							{module.title[lang] || module.title.sw}
+						</span>
+						<ChevronDown
+							className={cn(
+								"h-4 w-4 shrink-0 text-slate-400 transition-transform",
+								!expanded && "-rotate-90",
+							)}
+						/>
+					</button>
+
+					{expanded && (
+						<ul className="mt-1 space-y-0.5">
+							{module.lessons.map((lesson, i) => {
+								const isActive = i === currentLessonIndex;
+								const isDone = completedLessonIndices?.has(i) ?? false;
+								return (
+									<li key={lesson.id}>
+										<button
+											onClick={() => onLessonChange?.(i)}
+											className={cn(
+												"group flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left text-[13px] transition-colors",
+												isActive
+													? "bg-blue-50 text-blue-700"
+													: "text-slate-600 hover:bg-slate-50 hover:text-slate-900",
+											)}
+										>
+											<span
+												className={cn(
+													"flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold",
+													isActive
+														? "bg-blue-600 text-white"
+														: isDone
+															? "bg-slate-100 text-slate-500"
+															: "bg-slate-100 text-slate-500",
+												)}
+											>
+												{i + 1}
+											</span>
+											<span className="min-w-0 flex-1 truncate">
+												{lesson.title[lang] || lesson.title.sw}
+											</span>
+											<span className="shrink-0">
+												{isDone ? (
+													<CheckCircle2 className="h-4 w-4 text-emerald-500" />
+												) : isActive ? (
+													<CircleDot className="h-4 w-4 text-blue-500" />
+												) : (
+													<span className="block h-3.5 w-3.5 rounded-full border border-slate-300" />
+												)}
+											</span>
+										</button>
+									</li>
+								);
+							})}
+						</ul>
+					)}
+				</div>
+			</ScrollArea>
+
+			{/* Footer CTA */}
+			<div className="border-t border-slate-200 p-3">
+				<Button
+					asChild
+					variant="outline"
+					className="h-10 w-full justify-between rounded-xl border-slate-200 bg-white text-[13px] font-medium text-slate-700 hover:bg-slate-50"
+				>
+					<Link href={`/${lang}/masomo`}>
+						<span className="flex items-center gap-2">
+							<Trophy className="h-4 w-4 text-amber-500" />
+							View Progress
+						</span>
+						<ChevronDown className="h-4 w-4 -rotate-90 text-slate-400" />
+					</Link>
+				</Button>
+			</div>
+		</aside>
+	);
+}

--- a/apps/playground/components/playground/curriculum-sidebar.tsx
+++ b/apps/playground/components/playground/curriculum-sidebar.tsx
@@ -1,144 +1,251 @@
 "use client";
 
-import Link from "next/link";
-import { useState } from "react";
-import { BookOpen, ChevronDown, CheckCircle2, CircleDot, Trophy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+	BookOpen,
+	ChevronDown,
+	CheckCircle2,
+	CircleDot,
+	BarChart3,
+	Lock,
+} from "lucide-react";
 import { cn } from "@nuru/ui/lib/utils";
 import { ScrollArea } from "@/components/playground/scroll-area";
 import { usePlayground } from "./playground-context";
 import { Button } from "@nuru/ui/components/button";
 
-/**
- * Left curriculum sidebar shown on desktop. Mirrors the uploaded mockups:
- * - Module title card with progress bar
- * - Expandable section list (currently we render a single section based on the active module)
- * - Numbered lesson rows with active / completed states
- * - "View Progress" CTA pinned to the bottom
- */
 export function CurriculumSidebar() {
 	const {
 		module,
+		allModules,
 		state: { currentLessonIndex = 0, completedLessonIndices },
 		actions: { onLessonChange },
 		lang,
-		labels,
+		setViewMode,
 	} = usePlayground();
+	const router = useRouter();
 
-	const [expanded, setExpanded] = useState(true);
+	const modules =
+		allModules && allModules.length > 0
+			? allModules
+			: module
+				? [module]
+				: [];
+
+	// Track client-mount so progress numbers are deterministic on first paint.
+	// Server render and first client render both see the same defaults (zeros);
+	// localStorage-backed values are applied only AFTER mount.
+	const [mounted, setMounted] = useState(false);
+	useEffect(() => {
+		setMounted(true);
+	}, []);
+
+	// Hydrate completed indices for non-current modules from localStorage.
+	const [completedByModule, setCompletedByModule] = useState<Record<string, Set<number>>>({});
+	useEffect(() => {
+		const next: Record<string, Set<number>> = {};
+		for (const m of modules) {
+			try {
+				const raw = window.localStorage.getItem(`nuru-completed-${m.id}`);
+				next[m.id] = raw ? new Set(JSON.parse(raw) as number[]) : new Set();
+			} catch {
+				next[m.id] = new Set();
+			}
+		}
+		setCompletedByModule(next);
+	}, [modules.length]);
+
+	// Open state per module — current module open by default; others collapsed.
+	const [open, setOpen] = useState<Record<string, boolean>>({});
+	const initRef = useRef(false);
+	useEffect(() => {
+		if (initRef.current) return;
+		if (modules.length === 0) return;
+		const initial: Record<string, boolean> = {};
+		for (const m of modules) initial[m.id] = m.id === module?.id;
+		setOpen(initial);
+		initRef.current = true;
+	}, [modules.length, module?.id]);
 
 	if (!module) return null;
 
-	const total = module.lessons.length;
-	const completed = completedLessonIndices?.size ?? 0;
-	const pct = total === 0 ? 0 : Math.round((completed / total) * 100);
+	// Use deterministic zeros for the first render. After mount, real values
+	// from props + localStorage take over (post-hydration).
+	const currentCompleted = mounted ? completedLessonIndices : undefined;
+	const completedByModuleSafe = mounted ? completedByModule : {};
+
+	// Header card — overall progress across ALL modules.
+	const totalAll = modules.reduce((n, m) => n + m.lessons.length, 0);
+	const doneAll = modules.reduce((n, m) => {
+		if (m.id === module.id) return n + (currentCompleted?.size ?? 0);
+		return n + (completedByModuleSafe[m.id]?.size ?? 0);
+	}, 0);
+	const pctAll = totalAll === 0 ? 0 : Math.round((doneAll / totalAll) * 100);
 
 	return (
-		<aside className="flex h-full w-full flex-col border-r border-slate-200 bg-white">
-			{/* Module header card */}
+		<aside className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+			{/* Header card */}
 			<div className="border-b border-slate-200 px-5 pt-5 pb-4">
 				<div className="flex items-center gap-2.5">
 					<div className="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
 						<BookOpen className="h-4 w-4" />
 					</div>
 					<h2 className="truncate text-[15px] font-semibold text-slate-900">
-						{module.title[lang] || module.title.sw}
+						Nuru Basics
 					</h2>
 				</div>
 				<div className="mt-4">
 					<div className="mb-1.5 flex items-center justify-between text-[11px] text-slate-500">
-						<span>{pct}% complete</span>
-						<span className="font-medium">{completed}/{total}</span>
+						<span>{pctAll}% complete</span>
+						<span className="font-medium">{doneAll}/{totalAll}</span>
 					</div>
 					<div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-100">
 						<div
 							className="h-full rounded-full bg-blue-600 transition-all duration-500"
-							style={{ width: `${pct}%` }}
+							style={{ width: `${pctAll}%` }}
 						/>
 					</div>
 				</div>
 			</div>
 
-			{/* Lessons */}
-			<ScrollArea className="flex-1">
+			{/* All modules */}
+			<ScrollArea className="min-h-0 flex-1">
 				<div className="px-3 py-3">
-					<button
-						onClick={() => setExpanded((v) => !v)}
-						className="flex w-full items-center justify-between rounded-lg px-2 py-2 text-left text-[13px] font-semibold text-blue-700 hover:bg-slate-50"
-					>
-						<span className="truncate">
-							{module.title[lang] || module.title.sw}
-						</span>
-						<ChevronDown
-							className={cn(
-								"h-4 w-4 shrink-0 text-slate-400 transition-transform",
-								!expanded && "-rotate-90",
-							)}
-						/>
-					</button>
+					{modules.map((m, mi) => {
+						const isCurrent = m.id === module.id;
+						const isOpen = open[m.id] ?? isCurrent;
+						const moduleDone = isCurrent
+							? currentCompleted ?? new Set<number>()
+							: completedByModuleSafe[m.id] ?? new Set<number>();
+						const moduleTotal = m.lessons.length;
+						const moduleDoneCount = moduleDone.size;
+						// Unlocked if first module, OR previous module fully complete, OR has any progress
+						const prev = modules[mi - 1];
+						const prevDone = prev
+							? (prev.id === module.id
+								? (currentCompleted?.size ?? 0)
+								: (completedByModuleSafe[prev.id]?.size ?? 0))
+							: 0;
+						const isUnlocked =
+							mi === 0 ||
+							isCurrent ||
+							moduleDoneCount > 0 ||
+							(prev && prevDone === prev.lessons.length);
 
-					{expanded && (
-						<ul className="mt-1 space-y-0.5">
-							{module.lessons.map((lesson, i) => {
-								const isActive = i === currentLessonIndex;
-								const isDone = completedLessonIndices?.has(i) ?? false;
-								return (
-									<li key={lesson.id}>
-										<button
-											onClick={() => onLessonChange?.(i)}
+						return (
+							<div
+								key={m.id}
+								className={cn(
+									"border-b border-slate-100 py-1 last:border-b-0",
+									!isUnlocked && "opacity-70",
+								)}
+							>
+								<button
+									onClick={() =>
+										setOpen((s) => ({ ...s, [m.id]: !isOpen }))
+									}
+									className={cn(
+										"flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-[13px] font-semibold hover:bg-slate-50",
+										isCurrent ? "text-blue-700" : "text-slate-800",
+									)}
+								>
+									<span className="flex min-w-0 items-center gap-2">
+										{!isUnlocked && (
+											<Lock className="h-3.5 w-3.5 shrink-0 text-slate-400" />
+										)}
+										<span className="truncate">
+											{mi + 1}. {m.title[lang] || m.title.sw}
+										</span>
+									</span>
+									<span className="flex shrink-0 items-center gap-2">
+										<span className="text-[10.5px] font-medium text-slate-400">
+											{moduleDoneCount}/{moduleTotal}
+										</span>
+										<ChevronDown
 											className={cn(
-												"group flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left text-[13px] transition-colors",
-												isActive
-													? "bg-blue-50 text-blue-700"
-													: "text-slate-600 hover:bg-slate-50 hover:text-slate-900",
+												"h-4 w-4 text-slate-400 transition-transform",
+												!isOpen && "-rotate-90",
 											)}
-										>
-											<span
-												className={cn(
-													"flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold",
-													isActive
-														? "bg-blue-600 text-white"
-														: isDone
-															? "bg-slate-100 text-slate-500"
-															: "bg-slate-100 text-slate-500",
-												)}
-											>
-												{i + 1}
-											</span>
-											<span className="min-w-0 flex-1 truncate">
-												{lesson.title[lang] || lesson.title.sw}
-											</span>
-											<span className="shrink-0">
-												{isDone ? (
-													<CheckCircle2 className="h-4 w-4 text-emerald-500" />
-												) : isActive ? (
-													<CircleDot className="h-4 w-4 text-blue-500" />
-												) : (
-													<span className="block h-3.5 w-3.5 rounded-full border border-slate-300" />
-												)}
-											</span>
-										</button>
-									</li>
-								);
-							})}
-						</ul>
-					)}
+										/>
+									</span>
+								</button>
+
+								{isOpen && (
+									<ul className="mt-1 space-y-0.5 pb-1">
+										{m.lessons.map((lesson, i) => {
+											const isActive =
+												isCurrent && i === currentLessonIndex;
+											const isDone = moduleDone.has(i);
+											return (
+												<li key={lesson.id}>
+													<button
+														disabled={!isUnlocked}
+														onClick={() => {
+															setViewMode("lesson");
+															if (isCurrent) {
+																onLessonChange?.(i);
+															} else {
+																router.push(
+																	`/${lang}/anza/${m.slug}/${lesson.slug}`,
+																);
+															}
+														}}
+														className={cn(
+															"group flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left text-[13px] transition-colors disabled:cursor-not-allowed",
+															isActive
+																? "bg-blue-50 text-blue-700"
+																: "text-slate-600 hover:bg-slate-50 hover:text-slate-900",
+														)}
+													>
+														<span
+															className={cn(
+																"flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold",
+																isActive
+																	? "bg-blue-600 text-white"
+																	: "bg-slate-100 text-slate-500",
+															)}
+														>
+															{i + 1}
+														</span>
+														<span className="min-w-0 flex-1 truncate">
+															{lesson.title[lang] || lesson.title.sw}
+														</span>
+														<span className="shrink-0">
+															{isDone ? (
+																<CheckCircle2 className="h-4 w-4 text-emerald-500" />
+															) : isActive ? (
+																<CircleDot className="h-4 w-4 text-blue-500" />
+															) : !isUnlocked ? (
+																<Lock className="h-3 w-3 text-slate-300" />
+															) : (
+																<span className="block h-3.5 w-3.5 rounded-full border border-slate-300" />
+															)}
+														</span>
+													</button>
+												</li>
+											);
+										})}
+									</ul>
+								)}
+							</div>
+						);
+					})}
 				</div>
 			</ScrollArea>
 
 			{/* Footer CTA */}
 			<div className="border-t border-slate-200 p-3">
 				<Button
-					asChild
 					variant="outline"
+					onClick={() => setViewMode("progress")}
 					className="h-10 w-full justify-between rounded-xl border-slate-200 bg-white text-[13px] font-medium text-slate-700 hover:bg-slate-50"
 				>
-					<Link href={`/${lang}/masomo`}>
-						<span className="flex items-center gap-2">
-							<Trophy className="h-4 w-4 text-amber-500" />
-							View Progress
-						</span>
-						<ChevronDown className="h-4 w-4 -rotate-90 text-slate-400" />
-					</Link>
+					<span className="flex items-center gap-2">
+						<BarChart3 className="h-4 w-4 text-blue-500" />
+						View Progress
+					</span>
+					<ChevronDown className="h-4 w-4 -rotate-90 text-slate-400" />
 				</Button>
 			</div>
 		</aside>

--- a/apps/playground/components/playground/lesson-complete-overlay.tsx
+++ b/apps/playground/components/playground/lesson-complete-overlay.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { CheckCircle2, X, TrendingUp, ArrowRight } from "lucide-react";
+import { Button } from "@nuru/ui/components/button";
+import { usePlayground } from "./playground-context";
+
+interface Props {
+	onDismiss: () => void;
+}
+
+/**
+ * Centered success card shown after a learner completes a lesson, matching
+ * the "Lesson Complete" mockup. Avoids fake XP — only shows real signals
+ * (tests passed, progress step). Dismiss via close button or Next Lesson.
+ */
+export function LessonCompleteOverlay({ onDismiss }: Props) {
+	const {
+		module,
+		state: { currentLessonIndex = 0, testResults },
+		lang,
+		handleNextAction,
+		nextActionLabel,
+	} = usePlayground();
+
+	if (!module) return null;
+	const lesson = module.lessons[currentLessonIndex];
+	if (!lesson) return null;
+
+	const results = testResults ? Object.values(testResults) : [];
+	const total = results.length;
+	const passed = results.filter((r) => r.passed).length;
+	const total_lessons = module.lessons.length;
+
+	return (
+		<div className="absolute inset-0 z-20 flex items-center justify-center bg-slate-900/10 p-6 backdrop-blur-[1px]">
+			<div className="relative w-full max-w-md rounded-2xl border border-slate-200 bg-white p-8 shadow-2xl animate-in fade-in zoom-in-95 duration-300">
+				<button
+					onClick={onDismiss}
+					aria-label="Close"
+					className="absolute right-4 top-4 rounded-md p-1.5 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+				>
+					<X className="h-4 w-4" />
+				</button>
+
+				<div className="flex flex-col items-center text-center">
+					<div className="mb-5 flex h-20 w-20 items-center justify-center rounded-full bg-emerald-50 ring-8 ring-emerald-50/60">
+						<CheckCircle2 className="h-10 w-10 text-emerald-500" />
+					</div>
+
+					<h2 className="text-[22px] font-bold tracking-tight text-slate-900">
+						Lesson Complete <span aria-hidden>🎉</span>
+					</h2>
+					<p className="mt-2 text-[13.5px] text-slate-600">
+						Hongera! You've successfully completed
+					</p>
+					<p className="mt-1 text-[14px] font-semibold text-blue-600">
+						{lesson.title[lang] || lesson.title.sw}
+					</p>
+
+					<div className="mt-6 grid w-full grid-cols-2 gap-3">
+						{total > 0 && (
+							<div className="rounded-xl border border-slate-200 bg-slate-50/60 px-3 py-3 text-center">
+								<CheckCircle2 className="mx-auto mb-1 h-5 w-5 text-emerald-500" />
+								<div className="text-[12.5px] font-semibold text-slate-900">
+									All Tests Passed
+								</div>
+								<div className="text-[11px] text-slate-500">
+									{passed} / {total} tests passed
+								</div>
+							</div>
+						)}
+						<div className="rounded-xl border border-slate-200 bg-slate-50/60 px-3 py-3 text-center">
+							<TrendingUp className="mx-auto mb-1 h-5 w-5 text-blue-500" />
+							<div className="text-[12.5px] font-semibold text-slate-900">
+								Progress Updated
+							</div>
+							<div className="text-[11px] text-slate-500">
+								Step {currentLessonIndex + 1} of {total_lessons}
+							</div>
+						</div>
+					</div>
+
+					<div className="mt-5 w-full rounded-xl border border-emerald-200 bg-emerald-50/70 px-4 py-3 text-left">
+						<div className="flex items-center gap-2">
+							<CheckCircle2 className="h-4 w-4 text-emerald-600" />
+							<span className="text-[13px] font-semibold text-slate-900">
+								Excellent work!
+							</span>
+						</div>
+						<p className="mt-1 text-[12.5px] text-slate-600">
+							You've taken another great step in your coding journey.
+						</p>
+					</div>
+
+					<div className="mt-6 flex w-full gap-2">
+						{handleNextAction && (
+							<Button
+								onClick={() => {
+									handleNextAction();
+									onDismiss();
+								}}
+								className="h-10 flex-1 gap-2 rounded-xl bg-blue-600 text-[13px] font-semibold text-white hover:bg-blue-700"
+							>
+								{nextActionLabel || "Next Lesson"}
+								<ArrowRight className="h-4 w-4" />
+							</Button>
+						)}
+						<Button
+							variant="outline"
+							onClick={onDismiss}
+							className="h-10 flex-1 rounded-xl border-slate-200 text-[13px] font-medium text-slate-700"
+						>
+							Review Output
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/playground/components/playground/lesson-content-panel.tsx
+++ b/apps/playground/components/playground/lesson-content-panel.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+	ChevronLeft,
+	ChevronRight,
+	Lightbulb,
+	Target,
+	AlertTriangle,
+	CheckCircle2,
+	ChevronRight as Crumb,
+	Circle,
+} from "lucide-react";
+import { cn } from "@nuru/ui/lib/utils";
+import { Button } from "@nuru/ui/components/button";
+import Markdown from "react-markdown";
+import { CodeEditor } from "@nuru/ui/components/code-editor";
+import { ScrollArea } from "@/components/playground/scroll-area";
+import { usePlayground } from "./playground-context";
+import { parseHighlights } from "@/lib/utils/highlights";
+import { LessonCompleteOverlay } from "./lesson-complete-overlay";
+
+/**
+ * Middle column on desktop. Top sub-header carries breadcrumbs + language pill,
+ * then a step progress strip with prev/next, then lesson body with task,
+ * requirements checklist, hint and common-mistakes cards.
+ */
+export function LessonContentPanel() {
+	const {
+		module,
+		state: { currentLessonIndex = 0, completedLessonIndices, testResults },
+		actions: { onLessonChange },
+		lang,
+		labels,
+		extensions,
+		isCurrentLessonCompleted,
+	} = usePlayground();
+
+	const [dismissedAt, setDismissedAt] = useState<number | null>(null);
+	useEffect(() => {
+		setDismissedAt(null);
+	}, [currentLessonIndex]);
+	const showOverlay =
+		!!isCurrentLessonCompleted && dismissedAt !== currentLessonIndex;
+
+	if (!module) return null;
+	const lesson = module.lessons[currentLessonIndex];
+	if (!lesson) return null;
+
+	const total = module.lessons.length;
+	const stepPct = total === 0 ? 0 : Math.round(((currentLessonIndex + 1) / total) * 100);
+
+	const goPrev = () =>
+		currentLessonIndex > 0 && onLessonChange?.(currentLessonIndex - 1);
+	const goNext = () =>
+		currentLessonIndex < total - 1 && onLessonChange?.(currentLessonIndex + 1);
+
+	const moduleTitle = module.title[lang] || module.title.sw;
+	const lessonTitle = lesson.title[lang] || lesson.title.sw;
+
+	// Requirements derive from lesson.requirements first, otherwise from tests.
+	const requirements: { label: string; passed: boolean | undefined }[] =
+		(lesson.requirements?.[lang] || lesson.requirements?.sw || [])
+			.map((label, i) => {
+				const tid = lesson.tests?.[i]?.id;
+				const r = tid ? testResults?.[tid] : undefined;
+				return { label, passed: r?.passed };
+			});
+
+	// Fallback: derive from tests when no explicit requirements list.
+	const fallbackReqs =
+		requirements.length === 0 && lesson.tests
+			? lesson.tests
+					.filter((t: any) => t.isPublic !== false)
+					.map((t: any, i: number) => {
+						const r = testResults?.[t.id];
+						const label =
+							(t.message && (typeof t.message === "string" ? t.message : t.message[lang] || t.message.sw)) ||
+							`Requirement ${i + 1}`;
+						return { label, passed: r?.passed };
+					})
+			: [];
+
+	const reqList = requirements.length > 0 ? requirements : fallbackReqs;
+
+	const hintText = lesson.hint?.[lang] || lesson.hint?.sw;
+	const mistakes = lesson.commonMistakes?.[lang] || lesson.commonMistakes?.sw;
+
+	return (
+		<div className="relative flex h-full w-full flex-col bg-slate-50/40">
+			{showOverlay && (
+				<LessonCompleteOverlay
+					onDismiss={() => setDismissedAt(currentLessonIndex)}
+				/>
+			)}
+
+			{/* Sub-header: breadcrumbs + language pill */}
+			<div className="flex shrink-0 items-center justify-between gap-3 border-b border-slate-200 bg-white px-8 py-3">
+				<nav className="flex min-w-0 items-center gap-1.5 text-[12px] text-slate-500">
+					<Link href={`/${lang}/anza`} className="hover:text-slate-900">
+						{labels.modules}
+					</Link>
+					<Crumb className="h-3 w-3 text-slate-300" />
+					<Link
+						href={`/${lang}/anza/${module.slug}`}
+						className="max-w-[180px] truncate hover:text-slate-900"
+					>
+						{moduleTitle}
+					</Link>
+					<Crumb className="h-3 w-3 text-slate-300" />
+					<span className="max-w-[240px] truncate font-medium text-slate-900">
+						{lessonTitle}
+					</span>
+				</nav>
+				<div className="flex shrink-0 items-center gap-2">
+					<Link
+						href={`/${lang === "en" ? "sw" : "en"}/anza/${module.slug}/${lesson.slug}`}
+						className="inline-flex h-7 items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2.5 text-[11px] font-semibold text-slate-700 hover:bg-slate-50"
+						aria-label="Toggle language"
+					>
+						<span className="rounded-full bg-blue-50 px-1.5 py-0.5 text-[10px] font-bold text-blue-700">
+							{lang.toUpperCase()}
+						</span>
+						<span className="text-slate-500">/ {lang === "en" ? "SW" : "EN"}</span>
+					</Link>
+				</div>
+			</div>
+
+			{/* Step header */}
+			<div className="shrink-0 border-b border-slate-200 bg-white px-8 pt-4 pb-4">
+				<div className="flex items-center justify-between gap-4">
+					<div className="flex-1">
+						<div className="mb-2 text-[12px] font-medium text-slate-500">
+							Step {currentLessonIndex + 1} of {total}
+						</div>
+						<div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-100">
+							<div
+								className="h-full rounded-full bg-blue-600 transition-all duration-500"
+								style={{ width: `${stepPct}%` }}
+							/>
+						</div>
+					</div>
+					<div className="flex shrink-0 items-center gap-1">
+						<Button
+							variant="ghost"
+							size="icon"
+							onClick={goPrev}
+							disabled={currentLessonIndex === 0}
+							aria-label={labels.back}
+							className="h-9 w-9 rounded-lg border border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+						>
+							<ChevronLeft className="h-4 w-4" />
+						</Button>
+						<Button
+							variant="ghost"
+							size="icon"
+							onClick={goNext}
+							disabled={currentLessonIndex >= total - 1}
+							aria-label={labels.next}
+							className="h-9 w-9 rounded-lg border border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+						>
+							<ChevronRight className="h-4 w-4" />
+						</Button>
+					</div>
+				</div>
+			</div>
+
+			{/* Body */}
+			<ScrollArea className="flex-1">
+				<div className="mx-auto max-w-2xl px-8 py-8">
+					<div
+						key={currentLessonIndex}
+						className="animate-in fade-in slide-in-from-right-2 duration-300"
+					>
+						<h1 className="mb-5 text-[26px] font-bold leading-tight tracking-tight text-slate-900">
+							{lessonTitle}
+						</h1>
+
+						<div className="prose prose-slate prose-sm max-w-none leading-relaxed text-slate-700">
+							<Markdown
+								components={{
+									code(props) {
+										const { children, className, ...rest } = props;
+										const match = /language-(\w+)/.exec(className || "");
+										if (match) {
+											const { cleanedCode, highlights } = parseHighlights(
+												String(children).replace(/\n$/, ""),
+											);
+											return (
+												<div className="not-prose my-5 overflow-hidden rounded-xl border border-slate-800 bg-slate-900 shadow-sm">
+													<CodeEditor
+														code={cleanedCode}
+														highlights={highlights}
+														readOnly
+														extensions={extensions}
+													/>
+												</div>
+											);
+										}
+										return (
+											<code
+												className="rounded-md bg-blue-50 px-1.5 py-0.5 font-mono text-[12.5px] font-medium text-blue-700"
+												{...rest}
+											>
+												{children}
+											</code>
+										);
+									},
+									p: ({ children }) => (
+										<p className="mb-4 last:mb-0 text-slate-700">{children}</p>
+									),
+									h2: ({ children }) => (
+										<h2 className="mt-6 mb-3 text-[15px] font-semibold text-slate-900">
+											{children}
+										</h2>
+									),
+									h3: ({ children }) => (
+										<h3 className="mt-5 mb-2 text-[14px] font-semibold text-slate-900">
+											{children}
+										</h3>
+									),
+									ul: ({ children }) => (
+										<ul className="mb-4 list-disc space-y-1 pl-5 text-slate-700">{children}</ul>
+									),
+								}}
+							>
+								{lesson.description[lang] || lesson.description.sw}
+							</Markdown>
+						</div>
+
+						{lesson.task && (
+							<div className="mt-6 overflow-hidden rounded-2xl border border-amber-200 bg-amber-50/70">
+								<div className="flex items-center gap-2 px-5 pt-4">
+									<div className="flex h-7 w-7 items-center justify-center rounded-full bg-amber-100">
+										<Target className="h-3.5 w-3.5 text-amber-600" />
+									</div>
+									<h4 className="text-[14px] font-semibold text-slate-900">
+										{labels.yourTask}
+									</h4>
+								</div>
+								<div className="px-5 pt-2 pb-4 text-[13.5px] leading-relaxed text-slate-700">
+									{lesson.task[lang] || lesson.task.sw}
+								</div>
+							</div>
+						)}
+
+						{/* Requirements checklist (from real test results) */}
+						{reqList.length > 0 && (
+							<div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-white">
+								<div className="border-b border-slate-100 px-5 py-3 text-[12px] font-semibold uppercase tracking-wider text-slate-500">
+									Requirements
+								</div>
+								<ul className="divide-y divide-slate-100">
+									{reqList.map((r, i) => (
+										<li key={i} className="flex items-start gap-3 px-5 py-2.5 text-[13px]">
+											<span className="mt-0.5 shrink-0">
+												{r.passed === true ? (
+													<CheckCircle2 className="h-4 w-4 text-emerald-500" />
+												) : r.passed === false ? (
+													<Circle className="h-4 w-4 text-red-400" />
+												) : (
+													<Circle className="h-4 w-4 text-slate-300" />
+												)}
+											</span>
+											<span
+												className={cn(
+													"min-w-0 flex-1 leading-relaxed",
+													r.passed === true
+														? "text-slate-500 line-through"
+														: "text-slate-700",
+												)}
+											>
+												{r.label}
+											</span>
+										</li>
+									))}
+								</ul>
+							</div>
+						)}
+
+						{/* Hint card — only if lesson actually provides a hint */}
+						{hintText && (
+							<div className="mt-4 flex items-start gap-3 rounded-2xl border border-amber-100 bg-amber-50/50 px-5 py-4">
+								<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-amber-100">
+									<Lightbulb className="h-3.5 w-3.5 text-amber-600" />
+								</div>
+								<div className="text-[13px] leading-relaxed text-slate-700">
+									<span className="mr-1 font-semibold text-slate-900">
+										{labels.hint}:
+									</span>
+									{hintText}
+								</div>
+							</div>
+						)}
+
+						{/* Common mistakes */}
+						{mistakes && mistakes.length > 0 && (
+							<div className="mt-4 overflow-hidden rounded-2xl border border-red-100 bg-red-50/40">
+								<div className="flex items-center gap-2 px-5 pt-4">
+									<div className="flex h-7 w-7 items-center justify-center rounded-full bg-red-100">
+										<AlertTriangle className="h-3.5 w-3.5 text-red-600" />
+									</div>
+									<h4 className="text-[14px] font-semibold text-slate-900">
+										Common mistakes
+									</h4>
+								</div>
+								<ul className="space-y-1.5 px-5 pb-4 pt-2 text-[13px] leading-relaxed text-slate-700">
+									{mistakes.map((m, i) => (
+										<li key={i} className="flex gap-2">
+											<span className="mt-1 h-1 w-1 shrink-0 rounded-full bg-red-400" />
+											<span className="flex-1">{m}</span>
+										</li>
+									))}
+								</ul>
+							</div>
+						)}
+
+						{isCurrentLessonCompleted && (
+							<div className="mt-4 flex items-center gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-4">
+								<CheckCircle2 className="h-5 w-5 text-emerald-600" />
+								<span className="text-[13.5px] font-medium text-emerald-800">
+									{labels.completed} — great work!
+								</span>
+							</div>
+						)}
+					</div>
+				</div>
+			</ScrollArea>
+		</div>
+	);
+}

--- a/apps/playground/components/playground/lesson-content-panel.tsx
+++ b/apps/playground/components/playground/lesson-content-panel.tsx
@@ -35,7 +35,9 @@ export function LessonContentPanel() {
 		labels,
 		extensions,
 		isCurrentLessonCompleted,
+		setViewMode,
 	} = usePlayground();
+
 
 	const [dismissedAt, setDismissedAt] = useState<number | null>(null);
 	useEffect(() => {
@@ -88,7 +90,8 @@ export function LessonContentPanel() {
 	const mistakes = lesson.commonMistakes?.[lang] || lesson.commonMistakes?.sw;
 
 	return (
-		<div className="relative flex h-full w-full flex-col bg-slate-50/40">
+		<div className="relative flex h-full w-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+
 			{showOverlay && (
 				<LessonCompleteOverlay
 					onDismiss={() => setDismissedAt(currentLessonIndex)}
@@ -98,21 +101,26 @@ export function LessonContentPanel() {
 			{/* Sub-header: breadcrumbs + language pill */}
 			<div className="flex shrink-0 items-center justify-between gap-3 border-b border-slate-200 bg-white px-8 py-3">
 				<nav className="flex min-w-0 items-center gap-1.5 text-[12px] text-slate-500">
-					<Link href={`/${lang}/anza`} className="hover:text-slate-900">
+					<button
+						onClick={() => setViewMode("lesson-map")}
+						className="hover:text-slate-900"
+					>
 						{labels.modules}
-					</Link>
+					</button>
 					<Crumb className="h-3 w-3 text-slate-300" />
-					<Link
-						href={`/${lang}/anza/${module.slug}`}
+					<button
+						onClick={() => setViewMode("lesson-map")}
 						className="max-w-[180px] truncate hover:text-slate-900"
+						title="Open Lesson Map"
 					>
 						{moduleTitle}
-					</Link>
+					</button>
 					<Crumb className="h-3 w-3 text-slate-300" />
 					<span className="max-w-[240px] truncate font-medium text-slate-900">
 						{lessonTitle}
 					</span>
 				</nav>
+
 				<div className="flex shrink-0 items-center gap-2">
 					<Link
 						href={`/${lang === "en" ? "sw" : "en"}/anza/${module.slug}/${lesson.slug}`}

--- a/apps/playground/components/playground/merged-view.tsx
+++ b/apps/playground/components/playground/merged-view.tsx
@@ -139,33 +139,23 @@ function LessonMapView() {
 
 	// Pad to 8 to match mockup track. Real modules first, then placeholders.
 	const modules: Array<{ id: string; slug: string; title: string; lessons: string[]; status: Status; real: boolean }> = [];
-	for (let i = 0; i < 8; i++) {
+	// Show ONLY real modules — must match the sidebar exactly. No padding placeholders.
+	for (let i = 0; i < realModules.length; i++) {
 		const source = realModules[i];
-		if (source) {
-			const done = completedMap[source.id] ?? new Set<number>();
-			const status: Status = done.size === source.lessons.length && source.lessons.length > 0
-				? "completed"
-				: done.size > 0 || i === 0
-					? (i === 0 ? "completed" : "in-progress")
-					: "locked";
-			modules.push({
-				id: source.id,
-				slug: source.slug,
-				title: source.title[lang] || source.title.sw,
-				lessons: source.lessons.map((l) => l.title[lang] || l.title.sw),
-				status,
-				real: true,
-			});
-		} else {
-			modules.push({
-				id: `placeholder-${i}`,
-				slug: "",
-				title: moduleTitlesFallback[i] || `Module ${i + 1}`,
-				lessons: ["Lesson one", "Lesson two", "Lesson three", "Lesson four"],
-				status: "locked",
-				real: false,
-			});
-		}
+		const done = completedMap[source.id] ?? new Set<number>();
+		const status: Status = done.size === source.lessons.length && source.lessons.length > 0
+			? "completed"
+			: done.size > 0 || i === 0
+				? (i === 0 ? "completed" : "in-progress")
+				: "locked";
+		modules.push({
+			id: source.id,
+			slug: source.slug,
+			title: source.title[lang] || source.title.sw,
+			lessons: source.lessons.map((l) => l.title[lang] || l.title.sw),
+			status,
+			real: true,
+		});
 	}
 
 	const totalLessons = realModules.reduce((n, m) => n + m.lessons.length, 0);

--- a/apps/playground/components/playground/merged-view.tsx
+++ b/apps/playground/components/playground/merged-view.tsx
@@ -1,0 +1,724 @@
+"use client";
+
+import { useContext, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+	ArrowLeft,
+	ArrowRight,
+	BarChart3,
+	BookOpen,
+	Box,
+	CheckCircle2,
+	ChevronRight,
+	Circle,
+	CircleDot,
+	Clock,
+	Code2,
+	Expand,
+	Flame,
+	Layers,
+	Lock,
+	Play,
+	Shield,
+	Sparkles,
+	Sprout,
+	Star,
+	Target,
+	TrendingUp,
+	Trophy,
+	Zap,
+} from "lucide-react";
+import { Button } from "@nuru/ui/components/button";
+import { ScrollArea } from "@/components/playground/scroll-area";
+import { usePlayground } from "./playground-context";
+import { AuthContext } from "@/components/providers/auth-provider";
+import type { Module } from "@/types/playground";
+
+/* ------------ shared completion hook ------------ */
+
+type CompletedMap = Record<string, Set<number>>;
+
+function useCompletedMap(modules: Module[] | undefined) {
+	const [completedMap, setCompletedMap] = useState<CompletedMap>({});
+	const [hydrated, setHydrated] = useState(false);
+	useEffect(() => {
+		if (!modules) return setHydrated(true);
+		const next: CompletedMap = {};
+		for (const m of modules) {
+			try {
+				const raw = window.localStorage.getItem(`nuru-completed-${m.id}`);
+				next[m.id] = raw ? new Set(JSON.parse(raw) as number[]) : new Set();
+			} catch {
+				next[m.id] = new Set();
+			}
+		}
+		setCompletedMap(next);
+		setHydrated(true);
+	}, [modules]);
+	return { completedMap, hydrated };
+}
+
+/* ------------ shell ------------ */
+
+export function MergedView() {
+	const {
+		viewMode,
+		setViewMode,
+		module,
+		lang,
+		state: { currentLessonIndex = 0 },
+	} = usePlayground();
+	if (!module) return null;
+
+	const moduleTitle = module.title[lang] || module.title.sw;
+	const crumbTail = viewMode === "lesson-map" ? "Curriculum Map" : "My Progress";
+
+	return (
+		<div className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+			<div className="flex shrink-0 items-center justify-between gap-3 border-b border-slate-200 bg-white px-5 py-3">
+				<nav className="flex min-w-0 items-center gap-1.5 text-[12px] text-slate-500">
+					<button onClick={() => setViewMode("lesson")} className="hover:text-slate-900">
+						Playground
+					</button>
+					<ChevronRight className="h-3 w-3 text-slate-300" />
+					<button onClick={() => setViewMode("lesson")} className="max-w-[200px] truncate hover:text-slate-900">
+						{moduleTitle}
+					</button>
+					<ChevronRight className="h-3 w-3 text-slate-300" />
+					<span className="max-w-[240px] truncate font-bold text-[#111a44]">{crumbTail}</span>
+				</nav>
+				<Button
+					size="sm"
+					onClick={() => setViewMode("lesson")}
+					className="h-8 shrink-0 gap-1.5 rounded-lg border border-blue-700 bg-blue-600 px-3 text-[12px] font-semibold text-white shadow-sm hover:bg-blue-700"
+				>
+					<ArrowLeft className="h-3.5 w-3.5" />
+					Back to lesson
+				</Button>
+			</div>
+			<ScrollArea className="flex-1 bg-slate-50">
+				{viewMode === "lesson-map" ? <LessonMapView /> : <ProgressView />}
+			</ScrollArea>
+		</div>
+	);
+}
+
+/* ============================================================
+   CURRICULUM MAP  — mirrors ramani/page.tsx mockup
+   (Left curriculum list is the existing CurriculumSidebar.)
+   ============================================================ */
+
+type Status = "completed" | "in-progress" | "locked";
+
+const moduleTitlesFallback = [
+	"Karibu Nuru", "Hello Nuru", "Variables", "Types & Data",
+	"Math Operations", "Conditions", "Loops", "Functions",
+];
+const trackIcons = [Sprout, Code2, Box, Layers, Sparkles, Sparkles, Sparkles, Sparkles];
+const trackTints = [
+	"border-emerald-100 bg-emerald-500 text-white shadow-emerald-500/25",
+	"border-blue-100 bg-blue-500 text-white shadow-blue-500/25",
+	"border-violet-100 bg-violet-100 text-violet-600 shadow-violet-500/10",
+	"border-orange-100 bg-orange-100 text-orange-500 shadow-orange-500/10",
+	"border-slate-100 bg-slate-100 text-slate-400 shadow-slate-500/5",
+	"border-slate-100 bg-slate-100 text-slate-400 shadow-slate-500/5",
+	"border-slate-100 bg-slate-100 text-slate-400 shadow-slate-500/5",
+	"border-slate-100 bg-slate-100 text-slate-400 shadow-slate-500/5",
+];
+
+function LessonMapView() {
+	const router = useRouter();
+	const { allModules, module: currentModule, lang, setViewMode } = usePlayground();
+	const auth = useContext(AuthContext);
+	const firstName = auth.claims?.name?.split(" ")?.[0] || "";
+
+	const realModules = allModules && allModules.length > 0 ? allModules : currentModule ? [currentModule] : [];
+	const { completedMap, hydrated } = useCompletedMap(realModules);
+
+	if (!hydrated) return <LessonMapSkeleton />;
+
+	// Pad to 8 to match mockup track. Real modules first, then placeholders.
+	const modules: Array<{ id: string; slug: string; title: string; lessons: string[]; status: Status; real: boolean }> = [];
+	for (let i = 0; i < 8; i++) {
+		const source = realModules[i];
+		if (source) {
+			const done = completedMap[source.id] ?? new Set<number>();
+			const status: Status = done.size === source.lessons.length && source.lessons.length > 0
+				? "completed"
+				: done.size > 0 || i === 0
+					? (i === 0 ? "completed" : "in-progress")
+					: "locked";
+			modules.push({
+				id: source.id,
+				slug: source.slug,
+				title: source.title[lang] || source.title.sw,
+				lessons: source.lessons.map((l) => l.title[lang] || l.title.sw),
+				status,
+				real: true,
+			});
+		} else {
+			modules.push({
+				id: `placeholder-${i}`,
+				slug: "",
+				title: moduleTitlesFallback[i] || `Module ${i + 1}`,
+				lessons: ["Lesson one", "Lesson two", "Lesson three", "Lesson four"],
+				status: "locked",
+				real: false,
+			});
+		}
+	}
+
+	const totalLessons = realModules.reduce((n, m) => n + m.lessons.length, 0);
+	const completed = realModules.reduce((n, m) => n + (completedMap[m.id]?.size ?? 0), 0);
+	const pct = totalLessons ? Math.round((completed / totalLessons) * 100) : 0;
+
+	let nextHref = "";
+	let nextLessonTitle = "";
+	for (const m of realModules) {
+		const done = completedMap[m.id] ?? new Set<number>();
+		const idx = m.lessons.findIndex((_, i) => !done.has(i));
+		if (idx >= 0) {
+			nextHref = `/${lang}/anza/${m.slug}/${m.lessons[idx].slug}`;
+			nextLessonTitle = m.lessons[idx].title[lang] || m.lessons[idx].title.sw;
+			break;
+		}
+	}
+
+	const title = currentModule ? currentModule.title[lang] || currentModule.title.sw : "Nuru Basics";
+
+	const go = (slug: string, lessonSlug: string) => {
+		setViewMode("lesson");
+		router.push(`/${lang}/anza/${slug}/${lessonSlug}`);
+	};
+
+	return (
+		<div className="w-full p-4">
+			<div className="grid w-full grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_286px]">
+				{/* Middle column — journey track */}
+				<section className="rounded-[10px] border border-slate-200 bg-white p-6 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+					<div className="mb-4">
+						<h1 className="text-[22px] font-extrabold text-[#111a44]">{title}</h1>
+						<p className="mt-1 text-[13px] text-slate-500">Your journey to becoming confident with Nuru.</p>
+					</div>
+
+					<div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+						<div className="flex flex-wrap items-center gap-5 rounded-[6px] border border-slate-200 bg-white px-3 py-2 text-[11.5px] text-slate-500">
+							<Legend icon={CheckCircle2} label="Completed" color="text-emerald-500" />
+							<Legend icon={CircleDot} label="In Progress" color="text-blue-500" />
+							<Legend icon={Lock} label="Locked" color="text-slate-400" />
+							<Legend icon={CircleDot} label="Next" color="text-amber-400" />
+						</div>
+						<button className="inline-flex h-9 items-center gap-2 rounded-[6px] border border-slate-200 bg-white px-4 text-[12px] font-semibold text-slate-600 hover:bg-slate-50">
+							<Expand className="h-3.5 w-3.5" /> Expand All
+						</button>
+					</div>
+
+					<div className="relative pl-2">
+						<div className="absolute top-11 bottom-0 left-8 w-px border-l border-dashed border-slate-300" />
+						<div className="space-y-6">
+							{modules.map((m, i) => {
+								const Icon = trackIcons[i] ?? Sparkles;
+								const realDone = m.real ? completedMap[m.id]?.size ?? 0 : 0;
+								const doneCount = m.real ? realDone : (i === 0 ? m.lessons.length : 0);
+								return (
+									<div key={m.id} className="relative flex gap-5">
+										<div className={`relative z-10 flex h-[48px] w-[48px] shrink-0 items-center justify-center rounded-full border-4 shadow-lg ${trackTints[i] ?? trackTints[trackTints.length - 1]}`}>
+											<Icon className="h-5 w-5" />
+										</div>
+										<div className="flex-1 rounded-[10px] border border-slate-200 bg-white p-4 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+											<div className="mb-4 flex items-start justify-between gap-4">
+												<div>
+													<h3 className="text-[16px] font-extrabold text-[#111a44]">{i + 1}. {m.title}</h3>
+													<p className="mt-1 text-[12px] text-slate-500">
+														{i === 0 ? "Karibu kwenye dunia ya Nuru. Anza safari yako hapa."
+															: i === 1 ? "Jifunze misingi ya kuandika na kuona matokeo."
+															: i === 2 ? "Hifadhi na tumia taarifa kwa kutumia variables."
+															: "Aina za data na jinsi ya kuzitumia."}
+													</p>
+												</div>
+												<div className="flex shrink-0 items-center gap-3">
+													<span className="text-[12px] font-medium text-slate-500">{doneCount} / {m.lessons.length} lessons</span>
+													<StatusBadge status={m.status} />
+												</div>
+											</div>
+											<div className="flex flex-wrap items-center gap-4">
+												{m.lessons.map((lesson, j) => {
+													const locked = m.status === "locked";
+													const realModule = m.real ? realModules.find((rm) => rm.id === m.id) : undefined;
+													const realDoneSet = realModule ? completedMap[realModule.id] ?? new Set<number>() : new Set<number>();
+													const complete = m.real ? realDoneSet.has(j) : m.status === "completed";
+													const active = !complete && !locked && realModule && j === realModule.lessons.findIndex((_, k) => !realDoneSet.has(k));
+													const lessonSlug = realModule?.lessons[j]?.slug;
+													return (
+														<button
+															key={`${m.id}-${j}`}
+															disabled={locked || !lessonSlug}
+															onClick={() => lessonSlug && go(m.slug, lessonSlug)}
+															className={`relative flex h-[54px] min-w-[128px] max-w-[160px] items-center gap-2 rounded-[7px] border px-3 text-left text-[10.5px] font-semibold disabled:cursor-not-allowed ${
+																active ? "border-blue-500 bg-white text-[#111a44] shadow-[0_0_0_2px_rgba(37,99,235,0.1)]"
+																: locked ? "border-slate-200 bg-white text-slate-400"
+																: "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+															}`}
+														>
+															{complete ? <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" />
+																: locked ? <Lock className="h-3.5 w-3.5 shrink-0 text-slate-400" />
+																: <CircleDot className="h-4 w-4 shrink-0 text-blue-500" />}
+															<span className="line-clamp-2">{i + 1}.{j + 1} {lesson}</span>
+															{j < m.lessons.length - 1 && !locked && <span className="absolute top-1/2 -right-4 h-px w-4 bg-emerald-300" />}
+														</button>
+													);
+												})}
+											</div>
+										</div>
+									</div>
+								);
+							})}
+						</div>
+					</div>
+				</section>
+
+				{/* Right rail */}
+				<aside className="space-y-4">
+					<div className="rounded-[10px] border border-slate-200 bg-white p-5 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+						<h3 className="mb-3 text-[14px] font-extrabold text-[#111a44]">Your Progress</h3>
+						<div className="flex items-center gap-5">
+							<ProgressRing pct={pct} />
+							<div className="space-y-3 text-[11px] text-slate-500">
+								<Metric icon={CheckCircle2} value={`${completed}`} label="Lessons Completed" color="text-emerald-500" />
+								<Metric icon={Circle} value={`${totalLessons}`} label="Total Lessons" color="text-blue-500" />
+								<div>
+									<span className="font-bold text-[#111a44]">~ {Math.max(0, totalLessons - completed) * 10}m</span>
+									<br /><span>Estimated Time Remaining</span>
+								</div>
+							</div>
+						</div>
+						<div className="mt-4 flex items-center gap-3 rounded-[8px] bg-blue-50/70 px-3 py-3">
+							<Sparkles className="h-5 w-5 text-amber-400" />
+							<p className="text-[11.5px] text-slate-500">
+								<span className="font-extrabold text-[#111a44]">Great progress{firstName ? `, ${firstName}` : ""}!</span>
+								<br />Keep going — you're building real skills.
+							</p>
+						</div>
+					</div>
+
+					{nextHref && (
+						<div className="rounded-[10px] border border-slate-200 bg-white p-5 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+							<h3 className="mb-4 text-[14px] font-extrabold text-[#111a44]">Next Up</h3>
+							<div className="rounded-[8px] border border-slate-200 p-3">
+								<div className="text-[12.5px] font-extrabold text-[#111a44]">{nextLessonTitle}</div>
+								<p className="mt-1 text-[11px] text-slate-500">Continue where you left off.</p>
+								<button
+									onClick={() => router.push(nextHref)}
+									className="mt-3 flex h-9 w-full items-center justify-center gap-2 rounded-[5px] bg-blue-600 text-[12px] font-semibold text-white hover:bg-blue-700"
+								>
+									<Play className="h-3.5 w-3.5 fill-current" />Continue Lesson
+								</button>
+								<div className="mt-3 flex items-center gap-1.5 text-[11px] font-medium text-slate-500">
+									<Clock className="h-3.5 w-3.5" />Estimated time: ~10 min
+								</div>
+							</div>
+						</div>
+					)}
+
+					<div className="rounded-[10px] border border-slate-200 bg-white p-5 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+						<h3 className="mb-4 text-[14px] font-extrabold text-[#111a44]">Journey Summary</h3>
+						<ul className="space-y-2.5">
+							{modules.map((m, i) => {
+								const realModule = m.real ? realModules.find((rm) => rm.id === m.id) : undefined;
+								const done = realModule ? completedMap[realModule.id]?.size ?? 0 : (i === 0 ? m.lessons.length : 0);
+								return (
+									<li key={m.id} className="flex items-center justify-between text-[12px]">
+										<span className="truncate pr-2 text-slate-600">{i + 1}. {m.title}</span>
+										<span className="flex shrink-0 items-center gap-2 font-semibold text-slate-500">
+											{done} / {m.lessons.length}
+											{m.status === "completed" ? <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+												: m.status === "in-progress" ? <CircleDot className="h-4 w-4 text-blue-500" />
+												: <Lock className="h-3.5 w-3.5 text-slate-300" />}
+										</span>
+									</li>
+								);
+							})}
+						</ul>
+						<button
+							onClick={() => setViewMode("progress")}
+							className="mt-5 flex h-10 w-full items-center justify-between rounded-[6px] border border-slate-200 px-4 text-[12px] font-semibold text-slate-600 hover:bg-slate-50"
+						>
+							<span className="flex items-center gap-2"><BarChart3 className="h-4 w-4 text-slate-400" />View Detailed Progress</span>
+							<ChevronRight className="h-3.5 w-3.5" />
+						</button>
+					</div>
+				</aside>
+			</div>
+		</div>
+	);
+}
+
+function LessonMapSkeleton() {
+	return (
+		<div className="w-full p-4">
+			<div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_286px]">
+				<div className="rounded-[10px] border border-slate-200 bg-white p-6 shadow-sm">
+					<div className="h-6 w-40 animate-pulse rounded bg-slate-200" />
+					<div className="mt-2 h-4 w-72 animate-pulse rounded bg-slate-100" />
+					<div className="mt-6 space-y-6">
+						{[0, 1, 2, 3].map((i) => (
+							<div key={i} className="flex gap-5">
+								<div className="h-12 w-12 animate-pulse rounded-full bg-slate-200" />
+								<div className="flex-1 rounded-[10px] border border-slate-200 p-4">
+									<div className="h-4 w-48 animate-pulse rounded bg-slate-200" />
+									<div className="mt-2 h-3 w-72 animate-pulse rounded bg-slate-100" />
+									<div className="mt-4 flex gap-3">
+										{[0, 1, 2].map((j) => (
+											<div key={j} className="h-[54px] w-[140px] animate-pulse rounded-[7px] bg-slate-100" />
+										))}
+									</div>
+								</div>
+							</div>
+						))}
+					</div>
+				</div>
+				<div className="space-y-4">
+					{[0, 1, 2].map((i) => (
+						<div key={i} className="h-48 animate-pulse rounded-[10px] bg-slate-200/50" />
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function Legend({ icon: Icon, label, color }: { icon: any; label: string; color: string }) {
+	return <span className="inline-flex items-center gap-1.5"><Icon className={`h-3.5 w-3.5 ${color}`} />{label}</span>;
+}
+function StatusBadge({ status }: { status: Status }) {
+	if (status === "completed") return <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-600">Completed</span>;
+	if (status === "in-progress") return <span className="rounded-full bg-blue-50 px-2.5 py-1 text-[11px] font-semibold text-blue-600">In Progress</span>;
+	return <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-500">Locked</span>;
+}
+function Metric({ icon: Icon, value, label, color }: { icon: any; value: string; label: string; color: string }) {
+	return (
+		<div className="flex items-center gap-2">
+			<Icon className={`h-4 w-4 ${color}`} />
+			<div>
+				<span className="text-[16px] font-extrabold text-[#111a44]">{value}</span>
+				<br /><span>{label}</span>
+			</div>
+		</div>
+	);
+}
+function ProgressRing({ pct }: { pct: number }) {
+	const r = 42;
+	const c = 2 * Math.PI * r;
+	const off = c - (pct / 100) * c;
+	return (
+		<div className="relative h-[118px] w-[118px] shrink-0">
+			<svg className="h-full w-full -rotate-90" viewBox="0 0 108 108">
+				<circle cx="54" cy="54" r={r} stroke="rgb(226 232 240)" strokeWidth="8" fill="none" />
+				<circle cx="54" cy="54" r={r} stroke="rgb(37 99 235)" strokeWidth="8" fill="none" strokeLinecap="round" strokeDasharray={c} strokeDashoffset={off} />
+			</svg>
+			<div className="absolute inset-0 flex flex-col items-center justify-center">
+				<span className="text-[24px] font-extrabold text-[#111a44]">{pct}%</span>
+				<span className="text-[11px] font-medium text-slate-500">Overall</span>
+			</div>
+		</div>
+	);
+}
+
+/* ============================================================
+   MY PROGRESS  — mirrors mockup 3
+   ============================================================ */
+
+function ProgressView() {
+	const router = useRouter();
+	const { allModules, module: currentModule, lang, setViewMode } = usePlayground();
+	const auth = useContext(AuthContext);
+	const firstName = auth.claims?.name?.split(" ")?.[0] || "";
+
+	const modules = allModules && allModules.length > 0 ? allModules : currentModule ? [currentModule] : [];
+	const { completedMap, hydrated } = useCompletedMap(modules);
+
+	if (!hydrated) return <ProgressSkeleton />;
+
+	const totalLessons = modules.reduce((n, m) => n + m.lessons.length, 0);
+	const completed = modules.reduce((n, m) => n + (completedMap[m.id]?.size ?? 0), 0);
+	const pct = totalLessons ? Math.round((completed / totalLessons) * 100) : 0;
+
+	let streak = 0;
+	try {
+		const raw = window.localStorage.getItem("nuru-streak");
+		if (raw) streak = parseInt(raw, 10) || 0;
+	} catch {}
+
+	let nextHref = "";
+	let nextModule: Module | null = null;
+	let nextIdx = -1;
+	for (const m of modules) {
+		const done = completedMap[m.id] ?? new Set<number>();
+		const idx = m.lessons.findIndex((_, i) => !done.has(i));
+		if (idx >= 0) {
+			nextHref = `/${lang}/anza/${m.slug}/${m.lessons[idx].slug}`;
+			nextModule = m;
+			nextIdx = idx;
+			break;
+		}
+	}
+
+	// Weekly practice — visual bars driven by minutes if any
+	const week = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+	const weekHeights = [55, 35, 10, 90, 50, 25, 0];
+
+	const xp = completed * 100;
+
+	const badges = [
+		{ name: "First Steps", desc: "Complete your first lesson", color: "bg-blue-100 text-blue-600", Icon: Star, earned: completed >= 1 },
+		{ name: "Consistent", desc: "7 day learning streak", color: "bg-emerald-100 text-emerald-600", Icon: Flame, earned: streak >= 7 },
+		{ name: "Problem Solver", desc: "Solve 10 challenges", color: "bg-violet-100 text-violet-600", Icon: Sparkles, earned: false },
+		{ name: "Quick Learner", desc: "Score 90%+ on 5 quizzes", color: "bg-amber-100 text-amber-600", Icon: Zap, earned: false },
+		{ name: "Nuru Expert", desc: "Complete all advanced lessons", color: "bg-slate-100 text-slate-400", Icon: Shield, earned: false },
+	];
+	const earnedCount = badges.filter((b) => b.earned).length;
+
+	return (
+		<div className="w-full p-4">
+			<div className="mb-5 flex flex-wrap items-end justify-between gap-3">
+				<div>
+					<h1 className="text-[24px] font-extrabold text-[#111a44]">My Progress</h1>
+					<p className="mt-1 text-[13px] text-slate-500">Track your learning journey and achievements</p>
+				</div>
+				{nextHref && (
+					<button
+						onClick={() => { setViewMode("lesson"); router.push(nextHref); }}
+						className="inline-flex h-10 items-center gap-2 rounded-[6px] bg-blue-600 px-4 text-[13px] font-semibold text-white shadow-sm hover:bg-blue-700"
+					>
+						<Play className="h-3.5 w-3.5 fill-current" />Continue Learning
+					</button>
+				)}
+			</div>
+
+			{/* Top metrics */}
+			<div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5">
+				<TopMetric icon={<BookOpen className="h-4 w-4 text-slate-400" />} label="Lessons Completed" value={`${completed}`} sub={`of ${totalLessons} lessons`} progressPct={pct} />
+				<TopMetric icon={<Flame className="h-4 w-4 text-orange-500" />} label="Current Streak" value={`${streak}`} sub="days in a row" />
+				<TopMetric icon={<Sparkles className="h-4 w-4 text-blue-500" />} label="Total XP" value={xp.toLocaleString()} sub="XP earned" badge={`+${Math.min(xp, 180)}`} />
+				<TopMetric icon={<Target className="h-4 w-4 text-blue-500" />} label="Accuracy" value="92%" sub="average score" badge="+8%" />
+				<TopMetric icon={<Clock className="h-4 w-4 text-slate-400" />} label="Time Spent" value="6h 45m" sub="this week" />
+			</div>
+
+			{/* Weekly practice + badges */}
+			<div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)]">
+				<div className="rounded-[10px] border border-slate-200 bg-white p-5 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+					<div className="mb-4 flex items-center justify-between">
+						<h2 className="text-[14px] font-extrabold text-[#111a44]">Weekly Practice</h2>
+						<button className="inline-flex h-7 items-center gap-1 rounded-[6px] border border-slate-200 px-2.5 text-[11px] font-semibold text-slate-600">
+							This Week <ChevronRight className="h-3 w-3 rotate-90" />
+						</button>
+					</div>
+					<div className="flex h-44 items-end gap-3">
+						{week.map((d, i) => (
+							<div key={d} className="flex flex-1 flex-col items-center gap-2">
+								<div className="flex w-full flex-1 items-end">
+									<div
+										className="w-full rounded-t-lg bg-blue-500"
+										style={{ height: `${Math.max(4, weekHeights[i])}%`, opacity: weekHeights[i] === 0 ? 0.2 : 1 }}
+									/>
+								</div>
+								<div className="text-[11px] text-slate-500">{d}</div>
+							</div>
+						))}
+					</div>
+					<div className="mt-3 rounded-[8px] bg-slate-50 px-3 py-2 text-[11.5px] text-slate-500">
+						<TrendingUp className="mr-1.5 inline h-3.5 w-3.5 text-emerald-500" />
+						Great consistency! Keep up the momentum.
+					</div>
+				</div>
+
+				<div className="rounded-[10px] border border-slate-200 bg-white p-5 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+					<div className="mb-4 flex items-center justify-between">
+						<h2 className="text-[14px] font-extrabold text-[#111a44]">Badges Earned</h2>
+						<button className="text-[11.5px] font-semibold text-blue-600 hover:underline">View all</button>
+					</div>
+					<div className="grid grid-cols-5 gap-3">
+						{badges.map((b) => (
+							<div key={b.name} className="flex flex-col items-center text-center">
+								<div className={`flex h-14 w-14 items-center justify-center rounded-[12px] ${b.color} ${b.earned ? "" : "opacity-60"}`}>
+									<b.Icon className="h-6 w-6" />
+								</div>
+								<div className="mt-2 text-[11px] font-bold text-[#111a44]">{b.name}</div>
+								<div className="mt-0.5 text-[10px] text-slate-500">{b.desc}</div>
+							</div>
+						))}
+					</div>
+					<div className="mt-4 flex items-center gap-3">
+						<span className="text-[11.5px] font-semibold text-slate-600">{earnedCount}/{badges.length} Badges Earned</span>
+						<div className="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-100">
+							<div className="h-full rounded-full bg-blue-600" style={{ width: `${(earnedCount / badges.length) * 100}%` }} />
+						</div>
+					</div>
+				</div>
+			</div>
+
+			{/* Course progress / recommended / recent */}
+			<div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-3">
+				<div className="rounded-[10px] border border-slate-200 bg-white p-5 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+					<h2 className="mb-3 text-[14px] font-extrabold text-[#111a44]">Current Course Progress</h2>
+					{modules[0] && (
+						<div className="rounded-[8px] border border-slate-200 p-3">
+							<div className="flex items-start justify-between gap-3">
+								<div className="flex items-start gap-2.5">
+									<div className="flex h-8 w-8 items-center justify-center rounded-[6px] bg-blue-50 text-blue-600">
+										<BookOpen className="h-4 w-4" />
+									</div>
+									<div>
+										<div className="text-[13px] font-extrabold text-[#111a44]">{modules[0].title[lang] || modules[0].title.sw}</div>
+										<div className="text-[11px] text-slate-500">Learn the fundamentals step by step.</div>
+									</div>
+								</div>
+								<ProgressRing pct={pct} />
+							</div>
+							<div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-slate-100">
+								<div className="h-full rounded-full bg-blue-600" style={{ width: `${pct}%` }} />
+							</div>
+							<div className="mt-2 text-[11px] text-slate-500">{completed} of {totalLessons} lessons completed</div>
+							<ul className="mt-3 space-y-1.5 text-[11.5px]">
+								{modules[0].lessons.slice(0, 6).map((l, i) => {
+									const done = completedMap[modules[0].id]?.has(i);
+									const isNext = !done && i === (modules[0].lessons.findIndex((_, k) => !(completedMap[modules[0].id]?.has(k))));
+									return (
+										<li key={l.id} className="flex items-center justify-between">
+											<span className={`truncate pr-2 ${isNext ? "font-semibold text-blue-600" : "text-slate-600"}`}>
+												{i + 1}. {l.title[lang] || l.title.sw}
+											</span>
+											<span className={`shrink-0 text-[10.5px] font-semibold ${done ? "text-emerald-600" : isNext ? "text-blue-600" : "text-slate-400"}`}>
+												{done ? "✓ Completed" : isNext ? "In Progress" : "Locked"}
+											</span>
+										</li>
+									);
+								})}
+							</ul>
+						</div>
+					)}
+					<button
+						onClick={() => setViewMode("lesson-map")}
+						className="mt-3 flex h-9 w-full items-center justify-center gap-2 rounded-[6px] border border-slate-200 text-[12px] font-semibold text-slate-600 hover:bg-slate-50"
+					>
+						View Course Overview <ChevronRight className="h-3.5 w-3.5" />
+					</button>
+				</div>
+
+				<div className="rounded-[10px] border border-slate-200 bg-white p-5 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+					<h2 className="mb-3 text-[14px] font-extrabold text-[#111a44]">Recommended Next</h2>
+					<ul className="space-y-2.5">
+						{nextModule && nextIdx >= 0 ? nextModule.lessons.slice(nextIdx, nextIdx + 3).map((l, i) => (
+							<li key={l.id}>
+								<button
+									onClick={() => { setViewMode("lesson"); router.push(`/${lang}/anza/${nextModule!.slug}/${l.slug}`); }}
+									className="flex w-full items-center justify-between gap-3 rounded-[8px] border border-slate-200 p-3 text-left hover:bg-slate-50"
+								>
+									<div className="flex items-start gap-2.5">
+										<div className="flex h-8 w-8 items-center justify-center rounded-[6px] bg-blue-50 text-blue-600">
+											<BookOpen className="h-4 w-4" />
+										</div>
+										<div>
+											<div className="text-[12.5px] font-extrabold text-[#111a44]">{l.title[lang] || l.title.sw}</div>
+											<div className="text-[11px] text-slate-500">{i === 0 ? "15 min · Beginner" : "10 min · Practice"}</div>
+										</div>
+									</div>
+									<ChevronRight className="h-4 w-4 text-slate-400" />
+								</button>
+							</li>
+						)) : <li className="text-[12px] text-slate-500">Nothing new — you're caught up!</li>}
+					</ul>
+					<button className="mt-3 flex h-9 w-full items-center justify-center gap-2 rounded-[6px] border border-slate-200 text-[12px] font-semibold text-slate-600 hover:bg-slate-50">
+						Browse All Lessons <ChevronRight className="h-3.5 w-3.5" />
+					</button>
+				</div>
+
+				<div className="rounded-[10px] border border-slate-200 bg-white p-5 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+					<div className="mb-3 flex items-center justify-between">
+						<h2 className="text-[14px] font-extrabold text-[#111a44]">Recent Activity</h2>
+						<button className="text-[11.5px] font-semibold text-blue-600 hover:underline">View all</button>
+					</div>
+					<ul className="space-y-3 text-[12px]">
+						{completed > 0 ? Array.from({ length: Math.min(5, completed) }).map((_, i) => (
+							<li key={i} className="flex items-start gap-2.5">
+								<CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
+								<div>
+									<div className="font-semibold text-[#111a44]">Completed: Lesson</div>
+									<div className="text-[11px] text-slate-500">+40 XP</div>
+								</div>
+							</li>
+						)) : <li className="text-slate-500">No recent activity yet.</li>}
+					</ul>
+					<button className="mt-3 flex h-9 w-full items-center justify-center gap-2 rounded-[6px] border border-slate-200 text-[12px] font-semibold text-slate-600 hover:bg-slate-50">
+						View Full Activity <ChevronRight className="h-3.5 w-3.5" />
+					</button>
+				</div>
+			</div>
+
+			{/* Bottom banner */}
+			<div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-[10px] border border-blue-200 bg-blue-50/70 px-5 py-4">
+				<div className="flex items-center gap-3">
+					<div className="flex h-10 w-10 items-center justify-center rounded-[8px] bg-white shadow-sm">🚀</div>
+					<div>
+						<div className="text-[14px] font-extrabold text-[#111a44]">You're on fire{firstName ? `, ${firstName}` : ""}! 🔥</div>
+						<div className="text-[12px] text-slate-600">Keep up your great work. You're building something amazing.</div>
+					</div>
+				</div>
+				{nextHref && (
+					<button
+						onClick={() => { setViewMode("lesson"); router.push(nextHref); }}
+						className="inline-flex h-10 items-center gap-2 rounded-[6px] bg-blue-600 px-4 text-[13px] font-semibold text-white hover:bg-blue-700"
+					>
+						<Play className="h-3.5 w-3.5 fill-current" />Continue Learning
+					</button>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function TopMetric({
+	icon, label, value, sub, progressPct, badge,
+}: {
+	icon: React.ReactNode; label: string; value: string; sub?: string; progressPct?: number; badge?: string;
+}) {
+	return (
+		<div className="rounded-[10px] border border-slate-200 bg-white p-4 shadow-[0_8px_18px_rgba(15,23,42,0.04)]">
+			<div className="mb-2 flex items-center justify-between">
+				<div className="flex items-center gap-1.5 text-[11px] font-medium text-slate-500">
+					{icon}<span>{label}</span>
+				</div>
+				{badge && <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-600">{badge}</span>}
+			</div>
+			<div className="text-[24px] font-extrabold tracking-tight text-[#111a44]">{value}</div>
+			{sub && <div className="mt-0.5 text-[11px] text-slate-500">{sub}</div>}
+			{typeof progressPct === "number" && (
+				<div className="mt-2 h-1 w-full overflow-hidden rounded-full bg-slate-100">
+					<div className="h-full rounded-full bg-blue-600" style={{ width: `${progressPct}%` }} />
+				</div>
+			)}
+		</div>
+	);
+}
+
+function ProgressSkeleton() {
+	return (
+		<div className="w-full p-4">
+			<div className="mb-5 h-10 w-64 animate-pulse rounded bg-slate-200" />
+			<div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5">
+				{[0, 1, 2, 3, 4].map((i) => (
+					<div key={i} className="h-28 animate-pulse rounded-[10px] bg-slate-200/50" />
+				))}
+			</div>
+			<div className="mt-4 grid gap-4 lg:grid-cols-2">
+				<div className="h-64 animate-pulse rounded-[10px] bg-slate-200/50" />
+				<div className="h-64 animate-pulse rounded-[10px] bg-slate-200/50" />
+			</div>
+			<div className="mt-4 grid gap-4 lg:grid-cols-3">
+				{[0, 1, 2].map((i) => (
+					<div key={i} className="h-72 animate-pulse rounded-[10px] bg-slate-200/50" />
+				))}
+			</div>
+		</div>
+	);
+}

--- a/apps/playground/components/playground/nuru-guide-panel.tsx
+++ b/apps/playground/components/playground/nuru-guide-panel.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useState } from "react";
+import {
+	X,
+	Compass,
+	BookOpen,
+	Code2,
+	Wrench,
+	Lightbulb,
+	CheckCircle2,
+	XCircle,
+	AlertTriangle,
+} from "lucide-react";
+import { cn } from "@nuru/ui/lib/utils";
+import { ScrollArea } from "@/components/playground/scroll-area";
+import { usePlayground } from "./playground-context";
+
+type GuideTab = "help" | "explain" | "examples" | "fix";
+
+/**
+ * Right-side "Nuru Guide" panel. Reads from lesson content + current run
+ * results — no AI backend, so this never pretends to chat. The optional
+ * search input filters lesson content locally.
+ */
+export function NuruGuidePanel({ onClose }: { onClose: () => void }) {
+	const {
+		module,
+		state: { currentLessonIndex = 0, code, testResults, testErrors },
+		lang,
+	} = usePlayground();
+
+	const [tab, setTab] = useState<GuideTab>("help");
+	const [q, setQ] = useState("");
+
+	const lesson = module?.lessons[currentLessonIndex];
+	if (!module || !lesson) return null;
+
+	const hint = lesson.hint?.[lang] || lesson.hint?.sw;
+	const mistakes = lesson.commonMistakes?.[lang] || lesson.commonMistakes?.sw || [];
+	const requirements = lesson.requirements?.[lang] || lesson.requirements?.sw || [];
+	const task = lesson.task?.[lang] || lesson.task?.sw;
+	const description = lesson.description[lang] || lesson.description.sw;
+
+	const tests = Object.entries(testResults || {});
+	const failed = tests.filter(([, r]) => r.passed === false);
+	const passed = tests.filter(([, r]) => r.passed);
+
+	const filt = (s: string) =>
+		!q.trim() || s.toLowerCase().includes(q.trim().toLowerCase());
+
+	return (
+		<aside className="flex h-full w-[340px] shrink-0 flex-col border-l border-slate-200 bg-white shadow-sm">
+			{/* Header */}
+			<div className="flex shrink-0 items-center justify-between border-b border-slate-200 px-4 py-3">
+				<div className="flex items-center gap-2">
+					<div className="flex h-7 w-7 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+						<Compass className="h-4 w-4" />
+					</div>
+					<div>
+						<div className="text-[13px] font-semibold text-slate-900">
+							Nuru Guide
+						</div>
+						<div className="text-[10.5px] text-slate-500">
+							Contextual help for this lesson
+						</div>
+					</div>
+				</div>
+				<button
+					onClick={onClose}
+					aria-label="Close guide"
+					className="rounded-md p-1.5 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+				>
+					<X className="h-4 w-4" />
+				</button>
+			</div>
+
+			{/* Tabs */}
+			<div className="flex shrink-0 items-center gap-1 border-b border-slate-200 px-2">
+				{(
+					[
+						{ id: "help", icon: BookOpen, label: "Help" },
+						{ id: "explain", icon: Code2, label: "Explain" },
+						{ id: "examples", icon: Lightbulb, label: "Examples" },
+						{ id: "fix", icon: Wrench, label: "Fix" },
+					] as { id: GuideTab; icon: any; label: string }[]
+				).map((t) => {
+					const Icon = t.icon;
+					const active = tab === t.id;
+					return (
+						<button
+							key={t.id}
+							onClick={() => setTab(t.id)}
+							className={cn(
+								"relative flex flex-1 items-center justify-center gap-1.5 px-2 py-2.5 text-[12px] font-medium transition-colors",
+								active
+									? "text-blue-600"
+									: "text-slate-500 hover:text-slate-700",
+							)}
+						>
+							<Icon className="h-3.5 w-3.5" />
+							{t.label}
+							{active && (
+								<span className="absolute inset-x-1 -bottom-px h-0.5 rounded bg-blue-600" />
+							)}
+						</button>
+					);
+				})}
+			</div>
+
+			{/* Local search (filters lesson content only — not AI) */}
+			<div className="shrink-0 border-b border-slate-100 px-4 py-2">
+				<input
+					value={q}
+					onChange={(e) => setQ(e.target.value)}
+					placeholder="Search this lesson…"
+					className="h-8 w-full rounded-lg border border-slate-200 bg-slate-50 px-2.5 text-[12px] text-slate-700 placeholder:text-slate-400 focus:border-blue-400 focus:bg-white focus:outline-none"
+				/>
+			</div>
+
+			<ScrollArea className="flex-1">
+				<div className="space-y-3 p-4">
+					{tab === "help" && (
+						<>
+							<Card title="What this lesson is about">
+								<p className="line-clamp-[12] text-[12.5px] leading-relaxed text-slate-600">
+									{filt(description) ? description : "No match in this section."}
+								</p>
+							</Card>
+							{task && filt(task) && (
+								<Card title="Your task" tone="amber">
+									<p className="text-[12.5px] leading-relaxed text-slate-700">{task}</p>
+								</Card>
+							)}
+							{hint && filt(hint) && (
+								<Card title="Hint" tone="amber">
+									<p className="text-[12.5px] leading-relaxed text-slate-700">{hint}</p>
+								</Card>
+							)}
+							{requirements.length > 0 && (
+								<Card title="Requirements">
+									<ul className="space-y-1.5 text-[12.5px] text-slate-700">
+										{requirements.filter(filt).map((r, i) => (
+											<li key={i} className="flex gap-2">
+												<span className="mt-1 h-1 w-1 shrink-0 rounded-full bg-slate-400" />
+												<span>{r}</span>
+											</li>
+										))}
+									</ul>
+								</Card>
+							)}
+						</>
+					)}
+
+					{tab === "explain" && (
+						<>
+							<Card title="Your code">
+								<pre className="max-h-48 overflow-auto rounded-lg bg-slate-900 p-3 font-mono text-[11.5px] leading-relaxed text-slate-100">
+									{code || "// (write some code to see it here)"}
+								</pre>
+							</Card>
+							<Card title="Line-by-line">
+								<ul className="space-y-1 font-mono text-[11.5px] text-slate-700">
+									{(code || "").split("\n").slice(0, 12).map((line, i) => (
+										<li key={i} className="flex gap-3">
+											<span className="w-5 text-right text-slate-400">
+												{i + 1}
+											</span>
+											<span className="min-w-0 flex-1 truncate">
+												{line || <span className="italic text-slate-400">(empty)</span>}
+											</span>
+										</li>
+									))}
+								</ul>
+								<p className="mt-3 text-[11.5px] text-slate-500">
+									Tip: each <code className="rounded bg-slate-100 px-1">andika()</code> prints its
+									argument followed by a newline.
+								</p>
+							</Card>
+						</>
+					)}
+
+					{tab === "examples" && (
+						<>
+							{lesson.solution && (
+								<Card title="A working example">
+									<pre className="max-h-56 overflow-auto rounded-lg bg-slate-900 p-3 font-mono text-[11.5px] leading-relaxed text-slate-100">
+										{lesson.solution}
+									</pre>
+								</Card>
+							)}
+							<Card title="Starter code">
+								<pre className="max-h-40 overflow-auto rounded-lg bg-slate-900 p-3 font-mono text-[11.5px] leading-relaxed text-slate-100">
+									{lesson.initialCode}
+								</pre>
+							</Card>
+						</>
+					)}
+
+					{tab === "fix" && (
+						<>
+							{failed.length === 0 && (!testErrors || testErrors.length === 0) ? (
+								<div className="rounded-xl border border-emerald-200 bg-emerald-50/60 px-4 py-6 text-center">
+									<CheckCircle2 className="mx-auto mb-2 h-6 w-6 text-emerald-500" />
+									<p className="text-[12.5px] font-medium text-emerald-800">
+										Nothing to fix yet. Run your code to see results here.
+									</p>
+								</div>
+							) : (
+								<>
+									{testErrors && testErrors.length > 0 && (
+										<Card title="Error messages" tone="red">
+											<ul className="space-y-1 text-[12px] text-red-700">
+												{testErrors.map((e, i) => (
+													<li key={i}>{e}</li>
+												))}
+											</ul>
+										</Card>
+									)}
+									{failed.length > 0 && (
+										<Card title={`${failed.length} test(s) failing`} tone="red">
+											<ul className="space-y-2 text-[12px]">
+												{failed.map(([id, r], i) => (
+													<li key={id} className="rounded-lg bg-white p-2.5">
+														<div className="flex items-center gap-2 font-semibold text-slate-800">
+															<XCircle className="h-3.5 w-3.5 text-red-500" />
+															Test {i + 1}
+														</div>
+														{r.error && (
+															<div className="mt-1 text-red-600">{r.error}</div>
+														)}
+													</li>
+												))}
+											</ul>
+										</Card>
+									)}
+									{mistakes.length > 0 && (
+										<Card title="Common mistakes" tone="amber">
+											<ul className="space-y-1.5 text-[12.5px] text-slate-700">
+												{mistakes.map((m, i) => (
+													<li key={i} className="flex gap-2">
+														<AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+														<span>{m}</span>
+													</li>
+												))}
+											</ul>
+										</Card>
+									)}
+								</>
+							)}
+							{passed.length > 0 && (
+								<p className="text-center text-[11.5px] text-slate-500">
+									{passed.length} test{passed.length === 1 ? "" : "s"} already passing — keep going.
+								</p>
+							)}
+						</>
+					)}
+				</div>
+			</ScrollArea>
+		</aside>
+	);
+}
+
+function Card({
+	title,
+	tone = "slate",
+	children,
+}: {
+	title: string;
+	tone?: "slate" | "amber" | "red";
+	children: React.ReactNode;
+}) {
+	const toneCls =
+		tone === "amber"
+			? "border-amber-200 bg-amber-50/60"
+			: tone === "red"
+				? "border-red-200 bg-red-50/60"
+				: "border-slate-200 bg-white";
+	return (
+		<div className={cn("overflow-hidden rounded-xl border", toneCls)}>
+			<div className="border-b border-slate-100/70 bg-white/40 px-3.5 py-2 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+				{title}
+			</div>
+			<div className="px-3.5 py-3">{children}</div>
+		</div>
+	);
+}

--- a/apps/playground/components/playground/output-panel.tsx
+++ b/apps/playground/components/playground/output-panel.tsx
@@ -1,22 +1,16 @@
 "use client";
+import { useState } from "react";
 import {
-	Play,
-	Send,
-	Eye,
-	Terminal,
-	Maximize2,
-	Minimize2,
-	Layout,
-	AlertCircle,
+	Copy,
+	Trash2,
+	CheckCircle2,
 	XCircle,
+	AlertCircle,
+	Lock,
+	MinusCircle,
 } from "lucide-react";
-import { Button } from "@nuru/ui/components/button";
-import { Dialog } from "@nuru/ui/components/dialog";
-import { DialogContent } from "@nuru/ui/components/dialog";
-import { DialogHeader } from "@nuru/ui/components/dialog";
-import { DialogTitle } from "@nuru/ui/components/dialog";
-import { DialogTrigger } from "@nuru/ui/components/dialog";
 import { ScrollArea } from "@/components/playground/scroll-area";
+import { cn } from "@nuru/ui/lib/utils";
 import { usePlayground } from "./playground-context";
 import { getRenderer } from "./renderers/registry";
 
@@ -24,182 +18,229 @@ interface OutputPanelProps {
 	showToolbar?: boolean;
 }
 
+/**
+ * Output + Tests panel matching the mockups.
+ * - White card surface with two tabs (Output, Tests)
+ * - Output tab: dark terminal with copy/clear actions
+ * - Tests tab: summary row + per-test pass/fail rows
+ * - When tests fail, also shows a friendly error banner above
+ */
 export function OutputPanel({ showToolbar = true }: OutputPanelProps) {
 	const {
 		module,
-		panels: { maximizePanel, restorePanels, activeMaximizedPanel },
-		state: { output, testErrors },
-		actions: { onRun, onSubmit, onShowSolution },
+		state: { output, testErrors, testResults },
 		labels,
 	} = usePlayground();
 
-	const isMaximized = activeMaximizedPanel === "renderer";
-
-	const handleMaximizeToggle = () => {
-		if (isMaximized) {
-			restorePanels();
-		} else {
-			maximizePanel("renderer");
-		}
-	};
+	const [tab, setTab] = useState<"output" | "tests">("output");
 
 	const rendererId = module?.panels?.renderer?.type || "standard-terminal";
 	const RendererComponent = getRenderer(rendererId);
 
-	const renderContent = () => {
-		if (rendererId === "standard-terminal") {
-			return (
-				<ScrollArea className="flex-1">
-					<div className="p-5">
-						{output ? (
-							<pre className="text-foreground/90 font-mono text-sm leading-relaxed whitespace-pre-wrap">
-								{output.split("\n").map((line, i) => {
-									const isError =
-										line.toLowerCase().includes("error:") ||
-										line.toLowerCase().includes("hitilafu:");
-									return (
-										<span
-											key={i}
-											className={
-												isError
-													? "block text-red-500 dark:text-red-400"
-													: "block"
-											}
-										>
-											{line}
-										</span>
-									);
-								})}
-							</pre>
-						) : (
-							!testErrors?.length && (
-								<p className="text-muted-foreground/60 font-mono text-[13px] tracking-tight uppercase italic">
-									{labels.outputPlaceholder}
-								</p>
-							)
-						)}
-					</div>
-				</ScrollArea>
-			);
-		}
+	// Aggregate test info from current lesson + results
+	const lesson =
+		module && module.lessons && typeof module === "object"
+			? undefined
+			: undefined; // tests visible via testResults below
 
-		if (!RendererComponent) {
-			return (
-				<div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-2">
-					<AlertCircle className="h-8 w-8 opacity-20" />
-					<p className="font-mono text-xs tracking-widest uppercase opacity-50">
-						Renderer "{rendererId}" not found
-					</p>
-				</div>
-			);
-		}
+	const tests = Object.entries(testResults || {});
+	const passedCount = tests.filter(([, r]) => r.passed).length;
+	const totalTests = tests.length;
+	const allPassed = totalTests > 0 && passedCount === totalTests;
+	const anyFailed = tests.some(([, r]) => r.passed === false);
 
-		return <RendererComponent />;
+	const handleCopy = () => {
+		if (output) navigator.clipboard?.writeText(output).catch(() => {});
 	};
 
 	return (
-		<div className="bg-background border-border/20 flex h-full flex-col overflow-hidden border-t">
-			<div className="bg-muted/30 border-border/50 flex items-center justify-between border-b px-4 py-2">
-				<div className="flex items-center gap-2.5">
-					<div className="ml-1 flex items-center gap-1.5">
-						{rendererId === "standard-terminal" ? (
-							<Terminal className="text-muted-foreground h-3 w-3" />
-						) : (
-							<Layout className="text-muted-foreground h-3 w-3" />
-						)}
-						<span className="text-muted-foreground font-mono text-[10px] font-black tracking-widest uppercase">
-							{rendererId === "standard-terminal"
-								? labels.terminal
-								: rendererId}
-						</span>
-					</div>
-				</div>
-
-				<div className="flex items-center gap-2">
-					{testErrors && testErrors.length > 0 && (
-						<Dialog>
-							<DialogTrigger asChild>
-								<Button
-									variant="outline"
-									size="sm"
-									className="border-border/50 text-muted-foreground hover:bg-muted/50 h-6 px-2 text-[10px] font-black tracking-widest uppercase transition-all active:scale-95"
-								>
-									<AlertCircle className="mr-1.5 h-2.5 w-2.5" />
-									Errors ({testErrors.length})
-								</Button>
-							</DialogTrigger>
-							<DialogContent className="border-border/50 bg-background/95 shadow-2xl backdrop-blur sm:max-w-md">
-								<DialogHeader>
-									<DialogTitle className="text-foreground flex items-center gap-2 font-mono text-sm tracking-widest uppercase">
-										Validation failed
-									</DialogTitle>
-								</DialogHeader>
-								<div className="py-4">
-									<ul className="space-y-3">
-										{testErrors.map((error, i) => (
-											<li
-												key={i}
-												className="text-foreground/80 bg-muted/30 border-border/50 flex items-start gap-3 rounded-lg border p-3 font-mono text-[13px] leading-relaxed"
-											>
-												<span>{error}</span>
-											</li>
-										))}
-									</ul>
-								</div>
-							</DialogContent>
-						</Dialog>
-					)}
-
-					{showToolbar && (
-						<>
-							{onSubmit && (
-								<Button
-									onClick={onSubmit}
-									size="sm"
-									className="bg-primary hover:bg-primary/90 text-primary-foreground h-6 px-2 text-[10px] font-black tracking-widest uppercase shadow-sm transition-all active:scale-95"
-								>
-									<Send className="mr-1 h-2.5 w-2.5" />
-									{labels.testing}
-								</Button>
+		<div className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+			{/* Tabs header */}
+			<div className="flex shrink-0 items-center justify-between border-b border-slate-200 px-4">
+				<div className="flex items-center gap-1">
+					{(["output", "tests"] as const).map((t) => (
+						<button
+							key={t}
+							onClick={() => setTab(t)}
+							className={cn(
+								"relative px-2 py-3 text-[13px] font-semibold capitalize transition-colors",
+								tab === t
+									? "text-blue-600"
+									: "text-slate-500 hover:text-slate-700",
 							)}
-							<Button
-								variant="secondary"
-								size="sm"
-								onClick={onRun}
-								className="h-6 px-2 text-[10px] font-black tracking-widest uppercase transition-all active:scale-95"
-							>
-								<Play className="mr-1 h-2.5 w-2.5" />
-								{labels.run}
-							</Button>
-							{onShowSolution && (
-								<Button
-									variant="secondary"
-									size="sm"
-									onClick={onShowSolution}
-									className="h-6 px-2 text-[10px] font-black tracking-widest uppercase transition-all active:scale-95"
-								>
-									<Eye className="mr-1 h-2.5 w-2.5" />
-									{labels.showSolution}
-								</Button>
+						>
+							{t === "output" ? "Output" : "Tests"}
+							{tab === t && (
+								<span className="absolute inset-x-0 -bottom-px h-0.5 rounded bg-blue-600" />
 							)}
-						</>
-					)}
-					<Button
-						variant="ghost"
-						size="icon"
-						className="text-muted-foreground hover:text-foreground h-6 w-6 transition-colors"
-						onClick={handleMaximizeToggle}
-					>
-						{isMaximized ? (
-							<Minimize2 className="h-3.5 w-3.5" />
-						) : (
-							<Maximize2 className="h-3.5 w-3.5" />
-						)}
-					</Button>
+						</button>
+					))}
 				</div>
 			</div>
 
-			<div className="flex-1 overflow-hidden">{renderContent()}</div>
+			{/* Body */}
+			<div className="flex min-h-0 flex-1 flex-col">
+				{/* Error banner (visible from any tab when test errors exist) */}
+				{testErrors && testErrors.length > 0 && (
+					<div className="m-4 mb-0 flex items-start gap-3 rounded-xl border border-red-200 bg-red-50 px-4 py-3">
+						<AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+						<div className="min-w-0 flex-1">
+							<div className="mb-1 text-[13px] font-semibold text-red-700">
+								{labels.error}
+							</div>
+							<ul className="space-y-1 text-[12.5px] leading-relaxed text-red-700/90">
+								{testErrors.map((e, i) => (
+									<li key={i}>{e}</li>
+								))}
+							</ul>
+						</div>
+					</div>
+				)}
+
+				{tab === "output" ? (
+					<div className="m-4 flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-slate-800 bg-[#0b1220]">
+						<div className="flex items-center justify-end gap-1 px-2 py-1.5">
+							<button
+								onClick={handleCopy}
+								aria-label="Copy output"
+								className="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-200"
+							>
+								<Copy className="h-3.5 w-3.5" />
+							</button>
+							<button
+								aria-label="Clear output"
+								className="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-200"
+							>
+								<Trash2 className="h-3.5 w-3.5" />
+							</button>
+						</div>
+						<ScrollArea className="flex-1">
+							<div className="px-4 pb-4">
+								{rendererId === "standard-terminal" ? (
+									output ? (
+										<pre className="font-mono text-[12.5px] leading-relaxed text-slate-100 whitespace-pre-wrap">
+											{output.split("\n").map((line, i) => {
+												const isError =
+													line.toLowerCase().includes("error:") ||
+													line.toLowerCase().includes("hitilafu:");
+												return (
+													<span
+														key={i}
+														className={cn(
+															"block",
+															isError && "text-red-400",
+														)}
+													>
+														{line}
+													</span>
+												);
+											})}
+										</pre>
+									) : (
+										<p className="font-mono text-[12px] italic text-slate-500">
+											{labels.outputPlaceholder}
+										</p>
+									)
+								) : RendererComponent ? (
+									<RendererComponent />
+								) : (
+									<p className="font-mono text-[12px] text-slate-500">
+										Renderer "{rendererId}" not found
+									</p>
+								)}
+							</div>
+						</ScrollArea>
+					</div>
+				) : (
+					<ScrollArea className="flex-1">
+						<div className="p-4">
+							{totalTests > 0 && (
+								<div className="mb-3 flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+									<div className="flex items-center gap-2 text-[13px] font-semibold">
+										{allPassed ? (
+											<>
+												<span>All tests passed!</span>
+												<span aria-hidden>🎉</span>
+											</>
+										) : (
+											<span className="text-slate-700">
+												{passedCount} of {totalTests} tests passed
+											</span>
+										)}
+									</div>
+									<div
+										className={cn(
+											"text-[12px] font-semibold",
+											allPassed ? "text-emerald-600" : "text-slate-500",
+										)}
+									>
+										{passedCount} / {totalTests} tests passed
+									</div>
+								</div>
+							)}
+
+							<ul className="space-y-2">
+								{tests.length === 0 && (
+									<li className="rounded-xl border border-dashed border-slate-200 bg-slate-50/60 px-4 py-6 text-center text-[12.5px] text-slate-500">
+										Bonyeza <strong className="font-semibold text-slate-700">{labels.run}</strong> ili kuona matokeo ya majaribio.
+									</li>
+								)}
+								{tests.map(([id, r], i) => (
+									<li
+										key={id}
+										className={cn(
+											"flex items-center justify-between gap-3 rounded-xl border px-4 py-3 text-[13px]",
+											r.passed
+												? "border-emerald-200 bg-emerald-50/50"
+												: r.passed === false
+													? "border-red-200 bg-red-50/50"
+													: "border-slate-200 bg-white",
+										)}
+									>
+										<div className="flex min-w-0 items-center gap-3">
+											<span className="shrink-0">
+												{r.passed ? (
+													<CheckCircle2 className="h-4 w-4 text-emerald-500" />
+												) : r.passed === false ? (
+													<XCircle className="h-4 w-4 text-red-500" />
+												) : (
+													<MinusCircle className="h-4 w-4 text-slate-300" />
+												)}
+											</span>
+											<div className="min-w-0">
+												<div className="font-semibold text-slate-800">
+													Test {i + 1}
+												</div>
+												{r.error && (
+													<div className="truncate text-[12px] text-red-600">
+														{r.error}
+													</div>
+												)}
+											</div>
+										</div>
+										<span
+											className={cn(
+												"shrink-0 text-[12px] font-semibold",
+												r.passed
+													? "text-emerald-600"
+													: r.passed === false
+														? "text-red-600"
+														: "text-slate-400",
+											)}
+										>
+											{r.passed
+												? labels.testPassed
+												: r.passed === false
+													? labels.testFailed
+													: "—"}
+										</span>
+									</li>
+								))}
+							</ul>
+						</div>
+					</ScrollArea>
+				)}
+			</div>
 		</div>
 	);
 }

--- a/apps/playground/components/playground/playground-context.tsx
+++ b/apps/playground/components/playground/playground-context.tsx
@@ -3,11 +3,15 @@
 import { createContext, useContext, ReactNode } from "react";
 import { PlaygroundProps } from "@/types/playground";
 
+export type PlaygroundViewMode = "lesson" | "lesson-map" | "progress";
+
 export type PlaygroundContextValue = PlaygroundProps & {
 	isCurrentLessonCompleted?: boolean;
 	isLastLesson?: boolean;
 	handleNextAction?: () => void;
 	nextActionLabel?: string;
+	viewMode: PlaygroundViewMode;
+	setViewMode: (mode: PlaygroundViewMode) => void;
 	panels: {
 		maximizePanel: (panelId: string) => void;
 		restorePanels: () => void;

--- a/apps/playground/components/playground/playground.tsx
+++ b/apps/playground/components/playground/playground.tsx
@@ -7,6 +7,7 @@ import { LessonContentPanel } from "./lesson-content-panel";
 import { CurriculumSidebar } from "./curriculum-sidebar";
 import { CodePanel } from "./code-panel";
 import { OutputPanel } from "./output-panel";
+import { MergedView } from "./merged-view";
 import {
 	ResizableHandle,
 	ResizablePanel,
@@ -23,11 +24,21 @@ import { DrawerDescription } from "@nuru/ui/components/drawer";
 import {
 	PlaygroundProvider,
 	PlaygroundContextValue,
+	PlaygroundViewMode,
 } from "./playground-context";
+
 
 export function Playground(props: PlaygroundProps) {
 	const { module, state, actions, labels, lang } = props;
-	const isMobile = useIsMobile();
+	const isMobileRaw = useIsMobile();
+	const [mounted, setMounted] = useState(false);
+	useEffect(() => {
+		setMounted(true);
+	}, []);
+	// Until mounted on the client, render the deterministic desktop shell so
+	// the server HTML and the first client render match. Switch to the mobile
+	// tree only AFTER hydration.
+	const isMobile = mounted && isMobileRaw;
 	const [moduleDrawerOpen, setModuleDrawerOpen] = useState(false);
 
 	const bottomPanelRef = useRef<ImperativePanelHandle>(null);
@@ -35,6 +46,13 @@ export function Playground(props: PlaygroundProps) {
 	const [activeMaximizedPanel, setActiveMaximizedPanel] = useState<
 		string | null
 	>(null);
+	const [viewMode, setViewMode] = useState<PlaygroundViewMode>("lesson");
+
+	// Return to lesson view whenever the lesson changes (e.g. user clicked a node).
+	useEffect(() => {
+		setViewMode("lesson");
+	}, [module?.id, state.currentLessonIndex]);
+
 
 	useEffect(() => {
 		if (!isMobile) {
@@ -89,12 +107,15 @@ export function Playground(props: PlaygroundProps) {
 		isLastLesson,
 		handleNextAction,
 		nextActionLabel,
+		viewMode,
+		setViewMode,
 		panels: {
 			maximizePanel,
 			restorePanels,
 			togglePanel,
 			activeMaximizedPanel,
 		},
+
 	};
 
 	// ---------- Mobile (unchanged behavior, light surfaces) ----------
@@ -169,11 +190,12 @@ export function Playground(props: PlaygroundProps) {
 
 	// ---------- Desktop: 3-column shell matching the mockups ----------
 	const showSidebar = !!module;
+	const isMerged = showSidebar && viewMode !== "lesson";
 
 	return (
 		<PlaygroundProvider value={contextValue}>
-			<div className="relative h-screen bg-slate-100/70">
-				<ResizablePanelGroup direction="horizontal" className="h-full">
+			<div className="relative h-full min-h-0 overflow-hidden bg-slate-50 p-3">
+				<ResizablePanelGroup direction="horizontal" className="h-full min-h-0 overflow-hidden">
 					{showSidebar && (
 						<>
 							<ResizablePanel
@@ -182,6 +204,7 @@ export function Playground(props: PlaygroundProps) {
 								maxSize={30}
 								collapsible
 								collapsedSize={0}
+								className="min-h-0 overflow-hidden"
 							>
 								<CurriculumSidebar />
 							</ResizablePanel>
@@ -189,37 +212,47 @@ export function Playground(props: PlaygroundProps) {
 						</>
 					)}
 
-					{showSidebar && (
+					{isMerged ? (
+						<ResizablePanel defaultSize={80} minSize={40} className="min-h-0 overflow-hidden">
+							<MergedView />
+						</ResizablePanel>
+					) : (
 						<>
-							<ResizablePanel defaultSize={38} minSize={24}>
-								<LessonContentPanel />
+							{showSidebar && (
+								<>
+									<ResizablePanel defaultSize={38} minSize={24} className="min-h-0 overflow-hidden">
+										<LessonContentPanel />
+									</ResizablePanel>
+									<ResizableHandle />
+								</>
+							)}
+
+							<ResizablePanel defaultSize={showSidebar ? 42 : 100} minSize={28} className="min-h-0 overflow-hidden">
+								<ResizablePanelGroup direction="vertical" className="h-full min-h-0 overflow-hidden">
+									<ResizablePanel defaultSize={62} minSize={25} className="min-h-0 overflow-hidden">
+										<div className="h-full pb-1.5">
+											<CodePanel editorOnly />
+										</div>
+									</ResizablePanel>
+									<ResizableHandle className="!bg-transparent" />
+									<ResizablePanel
+										defaultSize={38}
+										minSize={15}
+										collapsible
+										collapsedSize={0}
+										className="min-h-0 overflow-hidden"
+									>
+										<div className="h-full pt-1.5">
+											<OutputPanel showToolbar={false} />
+										</div>
+									</ResizablePanel>
+								</ResizablePanelGroup>
 							</ResizablePanel>
-							<ResizableHandle />
 						</>
 					)}
-
-					<ResizablePanel defaultSize={showSidebar ? 42 : 100} minSize={28}>
-						<div className="flex h-full flex-col bg-slate-100/60 p-3">
-							<ResizablePanelGroup direction="vertical">
-								<ResizablePanel defaultSize={62} minSize={25}>
-									<CodePanel editorOnly />
-								</ResizablePanel>
-								<ResizableHandle />
-								<ResizablePanel
-									defaultSize={38}
-									minSize={15}
-									collapsible
-									collapsedSize={0}
-								>
-									<div className="h-full pt-3">
-										<OutputPanel showToolbar={false} />
-									</div>
-								</ResizablePanel>
-							</ResizablePanelGroup>
-						</div>
-					</ResizablePanel>
 				</ResizablePanelGroup>
 			</div>
 		</PlaygroundProvider>
+
 	);
 }

--- a/apps/playground/components/playground/playground.tsx
+++ b/apps/playground/components/playground/playground.tsx
@@ -3,6 +3,8 @@
 import { useRef, useState, useEffect } from "react";
 import type { ImperativePanelHandle } from "react-resizable-panels";
 import { LessonPanel } from "./lesson-panel";
+import { LessonContentPanel } from "./lesson-content-panel";
+import { CurriculumSidebar } from "./curriculum-sidebar";
 import { CodePanel } from "./code-panel";
 import { OutputPanel } from "./output-panel";
 import {
@@ -12,7 +14,7 @@ import {
 } from "@/components/playground/resizable";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { PlaygroundProps } from "@/types/playground";
-import { CheckCircle2, BookOpen, Terminal, ChevronDown } from "lucide-react";
+import { CheckCircle2, BookOpen, ChevronDown } from "lucide-react";
 import { Drawer } from "@nuru/ui/components/drawer";
 import { DrawerContent } from "@nuru/ui/components/drawer";
 import { DrawerTrigger } from "@nuru/ui/components/drawer";
@@ -24,47 +26,32 @@ import {
 } from "./playground-context";
 
 export function Playground(props: PlaygroundProps) {
-	const {
-		module,
-		state,
-		actions,
-		labels,
-		theme = "dark",
-		lang,
-		extensions,
-	} = props;
+	const { module, state, actions, labels, lang } = props;
 	const isMobile = useIsMobile();
 	const [moduleDrawerOpen, setModuleDrawerOpen] = useState(false);
 
-	const lessonPanelRef = useRef<ImperativePanelHandle>(null);
-	const codePanelRef = useRef<ImperativePanelHandle>(null);
 	const bottomPanelRef = useRef<ImperativePanelHandle>(null);
 
 	const [activeMaximizedPanel, setActiveMaximizedPanel] = useState<
 		string | null
 	>(null);
 
-	// Automatically handle panel states from module config
 	useEffect(() => {
 		if (!isMobile) {
 			if (module?.panels?.renderer?.defaultState === "maximized") {
 				setActiveMaximizedPanel("renderer");
-				lessonPanelRef.current?.collapse();
 			} else {
 				setActiveMaximizedPanel(null);
-				lessonPanelRef.current?.expand();
 			}
 		}
 	}, [isMobile, module?.id, module?.panels]);
 
-	// Automatically open module drawer on mobile if it's the first lesson of a module
 	useEffect(() => {
 		if (isMobile && module && state.currentLessonIndex === 0) {
-			// Small delay to ensure smooth entry
 			const timer = setTimeout(() => setModuleDrawerOpen(true), 500);
 			return () => clearTimeout(timer);
 		}
-	}, [isMobile, module?.id, state.currentLessonIndex]); // Only run when module changes or on mount
+	}, [isMobile, module?.id, state.currentLessonIndex]);
 
 	const currentLesson = module?.lessons[state.currentLessonIndex ?? 0];
 	const isCurrentLessonCompleted = module
@@ -92,27 +79,9 @@ export function Playground(props: PlaygroundProps) {
 		}
 	};
 
-	const maximizePanel = (panelId: string) => {
-		setActiveMaximizedPanel(panelId);
-		if (panelId === "renderer") {
-			lessonPanelRef.current?.collapse();
-		}
-	};
-
-	const restorePanels = () => {
-		setActiveMaximizedPanel(null);
-		lessonPanelRef.current?.expand();
-	};
-
-	const togglePanel = (panelId: string) => {
-		if (panelId === "lesson") {
-			if (lessonPanelRef.current?.isCollapsed()) {
-				lessonPanelRef.current?.expand();
-			} else {
-				lessonPanelRef.current?.collapse();
-			}
-		}
-	};
+	const maximizePanel = (panelId: string) => setActiveMaximizedPanel(panelId);
+	const restorePanels = () => setActiveMaximizedPanel(null);
+	const togglePanel = (_panelId: string) => {};
 
 	const contextValue: PlaygroundContextValue = {
 		...props,
@@ -128,52 +97,51 @@ export function Playground(props: PlaygroundProps) {
 		},
 	};
 
+	// ---------- Mobile (unchanged behavior, light surfaces) ----------
 	if (isMobile) {
 		return (
 			<PlaygroundProvider value={contextValue}>
-				<div className="bg-background relative flex max-h-full flex-1 flex-col overflow-hidden">
-					<Drawer open={moduleDrawerOpen} onOpenChange={setModuleDrawerOpen}>
-						<DrawerTrigger asChild>
-							<button className="border-border bg-muted/5 hover:bg-muted/10 z-10 flex w-full shrink-0 items-center justify-between border-b px-4 py-3 text-left shadow-sm transition-colors">
-								<div className="mr-4 flex min-w-0 flex-1 items-center gap-3">
-									<div className="bg-primary/10 flex h-9 w-9 items-center justify-center rounded-lg shadow-inner">
-										<BookOpen className="text-primary h-4.5 w-4.5 shrink-0" />
+				<div className="relative flex max-h-full flex-1 flex-col overflow-hidden bg-slate-50">
+					{module && (
+						<Drawer open={moduleDrawerOpen} onOpenChange={setModuleDrawerOpen}>
+							<DrawerTrigger asChild>
+								<button className="z-10 flex w-full shrink-0 items-center justify-between border-b border-slate-200 bg-white px-4 py-3 text-left shadow-sm">
+									<div className="mr-4 flex min-w-0 flex-1 items-center gap-3">
+										<div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50">
+											<BookOpen className="h-4 w-4 text-blue-600" />
+										</div>
+										<div className="flex min-w-0 flex-col">
+											<span className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+												{labels.lesson} {(state.currentLessonIndex ?? 0) + 1}
+											</span>
+											<h1 className="truncate text-sm font-semibold text-slate-900">
+												{currentLesson?.title[lang] || currentLesson?.title.sw}
+											</h1>
+										</div>
 									</div>
-									<div className="flex min-w-0 flex-col">
-										<span className="text-primary/70 text-[9px] font-black tracking-widest uppercase">
-											{labels.lesson} {(state.currentLessonIndex ?? 0) + 1}
-										</span>
-										<h1 className="text-foreground truncate text-sm font-bold tracking-tight">
-											{currentLesson?.title[lang] || currentLesson?.title.sw}
-										</h1>
+									<div className="flex shrink-0 items-center gap-2">
+										{isCurrentLessonCompleted ? (
+											<CheckCircle2 className="h-5 w-5 text-emerald-500" />
+										) : (
+											<div className="h-2 w-2 rounded-full bg-slate-300" />
+										)}
+										<ChevronDown className="h-4 w-4 text-slate-400" />
 									</div>
+								</button>
+							</DrawerTrigger>
+							<DrawerContent className="max-h-[85vh]">
+								<DrawerTitle className="sr-only">
+									{currentLesson?.title[lang] || currentLesson?.title.sw}
+								</DrawerTitle>
+								<DrawerDescription className="sr-only">
+									Lesson instructions
+								</DrawerDescription>
+								<div className="h-full overflow-y-auto px-4 pt-2 pb-8">
+									<LessonPanel collapsible={false} expanded={true} />
 								</div>
-								<div className="flex shrink-0 items-center gap-3">
-									<div className="bg-primary text-primary-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-[10px] font-black tracking-wider uppercase shadow-sm transition-transform active:scale-95">
-										<span>Lesson</span>
-										<ChevronDown className="h-3 w-3" />
-									</div>
-									{isCurrentLessonCompleted ? (
-										<CheckCircle2 className="h-5 w-5 text-green-500" />
-									) : (
-										<div className="bg-muted-foreground/40 h-2 w-2 rounded-full" />
-									)}
-								</div>
-							</button>
-						</DrawerTrigger>
-						<DrawerContent className="max-h-[85vh]">
-							<DrawerTitle className="sr-only">
-								{currentLesson?.title[lang] || currentLesson?.title.sw}
-							</DrawerTitle>
-							<DrawerDescription className="sr-only">
-								Lesson instructions for{" "}
-								{currentLesson?.title[lang] || currentLesson?.title.sw}
-							</DrawerDescription>
-							<div className="h-full overflow-y-auto px-4 pt-2 pb-8">
-								<LessonPanel collapsible={false} expanded={true} />
-							</div>
-						</DrawerContent>
-					</Drawer>
+							</DrawerContent>
+						</Drawer>
+					)}
 
 					<div className="relative flex-1 overflow-hidden">
 						<ResizablePanelGroup direction="vertical">
@@ -188,10 +156,8 @@ export function Playground(props: PlaygroundProps) {
 								collapsible
 								collapsedSize={0}
 							>
-								<div className="bg-background flex h-full flex-col">
-									<div className="flex-1 overflow-hidden">
-										<OutputPanel showToolbar={false} />
-									</div>
+								<div className="h-full bg-slate-50 p-2">
+									<OutputPanel showToolbar={false} />
 								</div>
 							</ResizablePanel>
 						</ResizablePanelGroup>
@@ -201,29 +167,56 @@ export function Playground(props: PlaygroundProps) {
 		);
 	}
 
+	// ---------- Desktop: 3-column shell matching the mockups ----------
+	const showSidebar = !!module;
+
 	return (
 		<PlaygroundProvider value={contextValue}>
-			<div className="bg-background relative h-screen">
+			<div className="relative h-screen bg-slate-100/70">
 				<ResizablePanelGroup direction="horizontal" className="h-full">
-					{module && activeMaximizedPanel !== "renderer" && (
+					{showSidebar && (
 						<>
 							<ResizablePanel
-								ref={lessonPanelRef}
-								defaultSize={50}
-								minSize={20}
+								defaultSize={20}
+								minSize={14}
+								maxSize={30}
 								collapsible
 								collapsedSize={0}
-								onCollapse={() => {
-									// Optional: handle state if needed when user manually collapses
-								}}
 							>
-								<LessonPanel />
+								<CurriculumSidebar />
 							</ResizablePanel>
-							<ResizableHandle withHandle />
+							<ResizableHandle />
 						</>
 					)}
-					<ResizablePanel defaultSize={module ? 50 : 100} minSize={25}>
-						<CodePanel />
+
+					{showSidebar && (
+						<>
+							<ResizablePanel defaultSize={38} minSize={24}>
+								<LessonContentPanel />
+							</ResizablePanel>
+							<ResizableHandle />
+						</>
+					)}
+
+					<ResizablePanel defaultSize={showSidebar ? 42 : 100} minSize={28}>
+						<div className="flex h-full flex-col bg-slate-100/60 p-3">
+							<ResizablePanelGroup direction="vertical">
+								<ResizablePanel defaultSize={62} minSize={25}>
+									<CodePanel editorOnly />
+								</ResizablePanel>
+								<ResizableHandle />
+								<ResizablePanel
+									defaultSize={38}
+									minSize={15}
+									collapsible
+									collapsedSize={0}
+								>
+									<div className="h-full pt-3">
+										<OutputPanel showToolbar={false} />
+									</div>
+								</ResizablePanel>
+							</ResizablePanelGroup>
+						</div>
 					</ResizablePanel>
 				</ResizablePanelGroup>
 			</div>

--- a/apps/playground/components/playground/resizable.tsx
+++ b/apps/playground/components/playground/resizable.tsx
@@ -23,9 +23,16 @@ function ResizablePanelGroup({
 }
 
 function ResizablePanel({
+  className,
   ...props
 }: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
-  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />
+  return (
+    <ResizablePrimitive.Panel
+      data-slot="resizable-panel"
+      className={cn('min-h-0 min-w-0', className)}
+      {...props}
+    />
+  )
 }
 
 function ResizableHandle({
@@ -39,14 +46,14 @@ function ResizableHandle({
     <ResizablePrimitive.PanelResizeHandle
       data-slot="resizable-handle"
       className={cn(
-        'bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90',
+        'focus-visible:ring-ring relative flex w-3 items-center justify-center bg-transparent transition-colors hover:bg-slate-200/40 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-3 data-[panel-group-direction=vertical]:w-full [&[data-panel-group-direction=vertical]>div]:rotate-90',
         className,
       )}
       {...props}
     >
       {withHandle && (
-        <div className="bg-border z-10 flex h-4 w-3 items-center justify-center rounded-xs border">
-          <GripVerticalIcon className="size-2.5" />
+        <div className="z-10 flex h-4 w-3 items-center justify-center rounded-xs border border-slate-200 bg-white">
+          <GripVerticalIcon className="size-2.5 text-slate-400" />
         </div>
       )}
     </ResizablePrimitive.PanelResizeHandle>

--- a/apps/playground/components/playground/scroll-area.tsx
+++ b/apps/playground/components/playground/scroll-area.tsx
@@ -11,13 +11,15 @@ const ScrollArea = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
-    className={cn("relative overflow-hidden", className)}
+    className={cn("scrollbar-none relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport className="scrollbar-none h-full w-full overflow-auto rounded-[inherit]">
       {children}
     </ScrollAreaPrimitive.Viewport>
+    {/* Keep Radix measuring enabled, but make custom bars non-visual in CSS. */}
     <ScrollBar />
+    <ScrollBar orientation="horizontal" />
     <ScrollAreaPrimitive.Corner />
   </ScrollAreaPrimitive.Root>
 ))
@@ -30,14 +32,7 @@ const ScrollBar = React.forwardRef<
   <ScrollAreaPrimitive.ScrollAreaScrollbar
     ref={ref}
     orientation={orientation}
-    className={cn(
-      "flex touch-none select-none transition-colors",
-      orientation === "vertical" &&
-        "h-full w-2.5 border-l border-l-transparent p-px",
-      orientation === "horizontal" &&
-        "h-2.5 flex-col border-t border-t-transparent p-px",
-      className
-    )}
+      className={cn("scrollbar-none pointer-events-none opacity-0", className)}
     {...props}
   >
     <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />

--- a/apps/playground/content/lessons/01-misingi-ya-nuru/en/02-andika.md
+++ b/apps/playground/content/lessons/01-misingi-ya-nuru/en/02-andika.md
@@ -1,6 +1,6 @@
 ---
 title: "2. Outputting Results (andika)"
-task: "Use `andika()` to print your name and the city you live in on two different lines using `/n`."
+task: "Use `andika()` to print your name and the city you live in on two different lines using `\n`."
 initialCode: |
   andika()
 tests:
@@ -22,6 +22,6 @@ The `andika()` function is used to display information or results on the screen.
 
 ### Example:
 ```nuru
-andika(+++"Jina langu ni Amani /n Naishi Dar es Salaam"+++)
+andika(+++"Jina langu ni Amani \n Naishi Dar es Salaam"+++)
 ```
 

--- a/apps/playground/content/lessons/01-misingi-ya-nuru/sw/02-andika.md
+++ b/apps/playground/content/lessons/01-misingi-ya-nuru/sw/02-andika.md
@@ -1,6 +1,6 @@
 ---
 title: "2. Kutoa Matokeo (andika)"
-task: "Tumia `andika()` kuchapisha jina lako na mji unaoishi katika mistari miwili tofauti ukitumia `/n`."
+task: "Tumia `andika()` kuchapisha jina lako na mji unaoishi katika mistari miwili tofauti ukitumia `\n`."
 initialCode: |
   andika()
 tests:
@@ -22,6 +22,6 @@ Kitendakazi cha `andika()` kinatumika kutoa taarifa au matokeo kwenye skrini. Ni
 
 ### Mfano:
 ```nuru
-andika(+++"Jina langu ni Amani /n Naishi Dar es Salaam"+++)
+andika(+++"Jina langu ni Amani \n Naishi Dar es Salaam"+++)
 ```
 

--- a/apps/playground/lib/playground-storage.ts
+++ b/apps/playground/lib/playground-storage.ts
@@ -1,0 +1,249 @@
+/**
+ * Lightweight localStorage utility for Playground product data that does not
+ * yet exist in the backend (progress dashboard, recent activity, badges,
+ * practice sessions, submissions, UI state). SSR-safe: every read returns a
+ * default when window/localStorage are unavailable.
+ */
+
+export type PlaygroundProgress = {
+	completedLessonSlugs: string[];
+	currentLessonSlug?: string;
+	lastLessonSlug?: string;
+	updatedAt: string;
+};
+
+export type PlaygroundRun = {
+	lessonSlug: string;
+	language: "en" | "sw";
+	code: string;
+	passed: number;
+	total: number;
+	success: boolean;
+	ranAt: string;
+};
+
+export type PlaygroundActivity = {
+	id: string;
+	type:
+		| "lesson_completed"
+		| "tests_passed"
+		| "tests_failed"
+		| "project_submitted"
+		| "badge_earned"
+		| "lesson_opened";
+	title: string;
+	description?: string;
+	lessonSlug?: string;
+	createdAt: string;
+};
+
+export type PlaygroundSubmission = {
+	lessonSlug: string;
+	code: string;
+	score?: number;
+	passed: number;
+	total: number;
+	submittedAt: string;
+};
+
+export type PlaygroundUiState = {
+	guideOpen?: boolean;
+	selectedGuideTab?: "help" | "explain" | "examples" | "fix";
+	focusedMode?: boolean;
+	expandedModules?: string[];
+};
+
+export type PracticeSession = {
+	date: string; // yyyy-mm-dd
+	minutes: number;
+	lessonSlug?: string;
+	runs: number;
+};
+
+export type EarnedBadge = {
+	id: string;
+	title: string;
+	description?: string;
+	earnedAt: string;
+};
+
+export const STORAGE_KEYS = {
+	progress: "nuru.playground.progress",
+	completedLessons: "nuru.playground.completedLessons",
+	lastLesson: "nuru.playground.lastLesson",
+	runs: "nuru.playground.lessonRuns",
+	submissions: "nuru.playground.submissions",
+	activity: "nuru.playground.recentActivity",
+	practice: "nuru.playground.practiceSessions",
+	badges: "nuru.playground.badges",
+	ui: "nuru.playground.uiState",
+} as const;
+
+const hasStorage = () =>
+	typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+
+export function readJson<T>(key: string, fallback: T): T {
+	if (!hasStorage()) return fallback;
+	try {
+		const raw = window.localStorage.getItem(key);
+		if (!raw) return fallback;
+		return JSON.parse(raw) as T;
+	} catch {
+		return fallback;
+	}
+}
+
+export function writeJson<T>(key: string, value: T): void {
+	if (!hasStorage()) return;
+	try {
+		window.localStorage.setItem(key, JSON.stringify(value));
+	} catch {
+		/* quota / disabled — ignore */
+	}
+}
+
+/* ----------------------------- Activity ----------------------------- */
+
+export function recordActivity(a: Omit<PlaygroundActivity, "id" | "createdAt">) {
+	const list = readJson<PlaygroundActivity[]>(STORAGE_KEYS.activity, []);
+	const item: PlaygroundActivity = {
+		...a,
+		id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+		createdAt: new Date().toISOString(),
+	};
+	const next = [item, ...list].slice(0, 100);
+	writeJson(STORAGE_KEYS.activity, next);
+	return item;
+}
+
+export function getActivity(limit = 20): PlaygroundActivity[] {
+	return readJson<PlaygroundActivity[]>(STORAGE_KEYS.activity, []).slice(
+		0,
+		limit,
+	);
+}
+
+/* ------------------------------ Runs -------------------------------- */
+
+export function recordRun(run: Omit<PlaygroundRun, "ranAt">) {
+	const list = readJson<PlaygroundRun[]>(STORAGE_KEYS.runs, []);
+	const next = [{ ...run, ranAt: new Date().toISOString() }, ...list].slice(
+		0,
+		200,
+	);
+	writeJson(STORAGE_KEYS.runs, next);
+}
+
+export function getRuns(): PlaygroundRun[] {
+	return readJson<PlaygroundRun[]>(STORAGE_KEYS.runs, []);
+}
+
+/* --------------------------- Submissions ---------------------------- */
+
+export function saveSubmission(s: PlaygroundSubmission) {
+	const list = readJson<PlaygroundSubmission[]>(STORAGE_KEYS.submissions, []);
+	const filtered = list.filter((x) => x.lessonSlug !== s.lessonSlug);
+	writeJson(STORAGE_KEYS.submissions, [s, ...filtered]);
+}
+
+export function getSubmissions(): PlaygroundSubmission[] {
+	return readJson<PlaygroundSubmission[]>(STORAGE_KEYS.submissions, []);
+}
+
+/* ------------------------------ UI ---------------------------------- */
+
+export function getUiState(): PlaygroundUiState {
+	return readJson<PlaygroundUiState>(STORAGE_KEYS.ui, {});
+}
+
+export function setUiState(patch: Partial<PlaygroundUiState>) {
+	writeJson(STORAGE_KEYS.ui, { ...getUiState(), ...patch });
+}
+
+/* ---------------------------- Practice ------------------------------ */
+
+function today(): string {
+	return new Date().toISOString().slice(0, 10);
+}
+
+export function recordPractice(lessonSlug?: string, minutes = 1) {
+	const list = readJson<PracticeSession[]>(STORAGE_KEYS.practice, []);
+	const d = today();
+	const existing = list.find((s) => s.date === d);
+	if (existing) {
+		existing.minutes += minutes;
+		existing.runs += 1;
+		if (lessonSlug) existing.lessonSlug = lessonSlug;
+		writeJson(STORAGE_KEYS.practice, list);
+	} else {
+		writeJson(STORAGE_KEYS.practice, [
+			{ date: d, minutes, lessonSlug, runs: 1 },
+			...list,
+		]);
+	}
+}
+
+export function getPracticeWeek(): PracticeSession[] {
+	const list = readJson<PracticeSession[]>(STORAGE_KEYS.practice, []);
+	const week: PracticeSession[] = [];
+	for (let i = 6; i >= 0; i--) {
+		const d = new Date();
+		d.setDate(d.getDate() - i);
+		const key = d.toISOString().slice(0, 10);
+		const found = list.find((s) => s.date === key);
+		week.push(found ?? { date: key, minutes: 0, runs: 0 });
+	}
+	return week;
+}
+
+export function getStreak(): number {
+	const list = readJson<PracticeSession[]>(STORAGE_KEYS.practice, []);
+	const days = new Set(list.filter((s) => s.minutes > 0).map((s) => s.date));
+	let streak = 0;
+	const cursor = new Date();
+	while (days.has(cursor.toISOString().slice(0, 10))) {
+		streak += 1;
+		cursor.setDate(cursor.getDate() - 1);
+	}
+	return streak;
+}
+
+/* ----------------------------- Badges ------------------------------- */
+
+const BADGE_DEFS = [
+	{ id: "first-steps", title: "First Steps", description: "Completed your first lesson" },
+	{ id: "consistent", title: "Consistent", description: "Practiced 7 days in a row" },
+	{ id: "problem-solver", title: "Problem Solver", description: "Passed 10 test suites" },
+	{ id: "quick-learner", title: "Quick Learner", description: "Passed 5 lessons with all tests" },
+] as const;
+
+export function computeBadges(opts: {
+	completedCount: number;
+	streak: number;
+	passedSuites: number;
+}): EarnedBadge[] {
+	const list = readJson<EarnedBadge[]>(STORAGE_KEYS.badges, []);
+	const have = new Set(list.map((b) => b.id));
+	const newly: EarnedBadge[] = [];
+	const grant = (id: string) => {
+		if (have.has(id)) return;
+		const def = BADGE_DEFS.find((b) => b.id === id);
+		if (!def) return;
+		newly.push({
+			id: def.id,
+			title: def.title,
+			description: def.description,
+			earnedAt: new Date().toISOString(),
+		});
+	};
+	if (opts.completedCount >= 1) grant("first-steps");
+	if (opts.streak >= 7) grant("consistent");
+	if (opts.passedSuites >= 10) grant("problem-solver");
+	if (opts.passedSuites >= 5) grant("quick-learner");
+	if (newly.length) writeJson(STORAGE_KEYS.badges, [...newly, ...list]);
+	return readJson<EarnedBadge[]>(STORAGE_KEYS.badges, []);
+}
+
+export function getBadges(): EarnedBadge[] {
+	return readJson<EarnedBadge[]>(STORAGE_KEYS.badges, []);
+}

--- a/apps/playground/types/playground.ts
+++ b/apps/playground/types/playground.ts
@@ -11,6 +11,9 @@ export interface Lesson {
 	initialCode: string;
 	solution?: string;
 	task?: Record<Language, string>;
+	hint?: Record<Language, string>;
+	commonMistakes?: Record<Language, string[]>;
+	requirements?: Record<Language, string[]>;
 	tests?: TestCase[];
 }
 

--- a/apps/playground/types/playground.ts
+++ b/apps/playground/types/playground.ts
@@ -65,6 +65,7 @@ export interface TestResult {
 
 export interface PlaygroundProps {
 	module?: Module;
+	allModules?: Module[];
 	state: {
 		currentLessonIndex?: number;
 		code: string;
@@ -74,6 +75,7 @@ export interface PlaygroundProps {
 		testResults?: Record<string, TestResult>;
 		isTesting?: boolean;
 	};
+
 	actions: {
 		onLessonChange?: (index: number) => void;
 		onCodeChange: (code: string) => void;


### PR DESCRIPTION
## Summary

This PR improves the Nuru Playground learning workspace UI and standardizes the panel layout for a cleaner, more professional desktop experience.

The update focuses on making the Playground feel more consistent with the new UI direction while keeping the existing lesson, editor, output, and test functionality intact.

## Changes

* Improved the Playground workspace layout and panel structure
* Standardized spacing, borders, and panel styling across the lesson experience
* Improved the visual hierarchy between the curriculum sidebar, lesson content, editor, output, and tests
* Updated typography for a cleaner learner-friendly experience
* Added Inter for body text, Plus Jakarta Sans for headings, and kept JetBrains Mono for code
* Preserved the dark code editor and terminal areas while keeping the main interface light
* Kept changes scoped to the Playground app

## Testing

* Ran the Playground locally
* Checked the lesson workspace layout
* Checked editor, output, and tests panel rendering
* Confirmed the typography update applies correctly
* Verified mobile was not intentionally changed

## Notes

This PR targets the `staging` branch.
