### PR TITLE
fix(playground): improve mobile workspace responsiveness

### DIFF
--- a/apps/playground/components/playground/code-panel.tsx
+++ b/apps/playground/components/playground/code-panel.tsx
@@ -1,6 +1,17 @@
 "use client";
 import React from "react";
-import { Play, RotateCcw, Maximize2, MoreVertical, AlignLeft, CircleDot, ArrowRight, Eye, HelpCircle } from "lucide-react";
+import {
+	Play,
+	RotateCcw,
+	Maximize2,
+	MoreVertical,
+	AlignLeft,
+	ArrowRight,
+	Eye,
+	HelpCircle,
+	BookOpen,
+	TerminalSquare,
+} from "lucide-react";
 import { CodeEditor } from "@nuru/ui/components/code-editor";
 import { OutputPanel } from "./output-panel";
 import { Button } from "@nuru/ui/components/button";
@@ -37,12 +48,13 @@ export function CodePanel({
 			onShowHint,
 			onReset,
 		},
-		theme,
 		labels,
 		extensions,
 		isCurrentLessonCompleted: isCompleted,
 		handleNextAction: onNextAction,
 		nextActionLabel,
+		viewMode,
+		setViewMode,
 	} = usePlayground();
 
 	const editorPanelRef = React.useRef<ImperativePanelHandle>(null);
@@ -67,15 +79,112 @@ export function CodePanel({
 	const onRun = onRunProp || onRunAction;
 	const isMaximized = activeMaximizedPanel === "editor";
 	const isDev = process.env.NODE_ENV === "development";
-
 	const fileExt = module?.executor === "python" ? "py" : "nr";
 
-	const editor = (
+	const mobileEditor = (
+		<div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-[20px] border border-slate-200 bg-[#071225] shadow-[0_18px_46px_-30px_rgba(15,23,42,0.55)]">
+			<div className="flex h-12 shrink-0 items-center justify-between border-b border-slate-700/70 px-4">
+				<div className="flex min-w-0 items-center gap-2.5">
+					<span className="truncate font-mono text-[14px] font-medium text-blue-400">
+						main.{fileExt}
+					</span>
+					<span className="block h-2.5 w-2.5 shrink-0 rounded-full bg-blue-500" />
+				</div>
+				<div className="flex items-center gap-1.5">
+					<button
+						onClick={() =>
+							isMaximized ? restorePanels() : maximizePanel("editor")
+						}
+						aria-label="Maximize editor"
+						className="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-100"
+					>
+						<Maximize2 className="h-4 w-4" />
+					</button>
+					<button
+						aria-label="More"
+						className="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-100"
+					>
+						<MoreVertical className="h-4 w-4" />
+					</button>
+				</div>
+			</div>
+
+			<div className="relative min-h-0 flex-1">
+				<CodeEditor
+					code={code}
+					onChange={onCodeChange}
+					theme="dark"
+					extensions={extensions}
+					className="[&_.cm-content]:text-[13px] [&_.cm-gutters]:text-[12px]"
+				/>
+			</div>
+
+			<div className="flex shrink-0 items-center justify-between gap-2 border-t border-slate-700/70 px-3 py-3">
+				<div className="grid grid-cols-3 gap-1.5">
+					<button
+						type="button"
+						onClick={() => setViewMode("lesson")}
+						className={cn(
+							"flex h-12 w-14 flex-col items-center justify-center gap-0.5 rounded-xl text-[10.5px] font-medium transition-colors",
+							viewMode === "lesson"
+								? "bg-slate-800/90 text-blue-400"
+								: "text-slate-300 hover:bg-slate-800/70",
+						)}
+					>
+						<BookOpen className="h-4 w-4" />
+						<span>Lesson</span>
+					</button>
+					<button
+						type="button"
+						onClick={() => setViewMode("output")}
+						className={cn(
+							"flex h-12 w-14 flex-col items-center justify-center gap-0.5 rounded-xl text-[10.5px] font-medium transition-colors",
+							viewMode === "output"
+								? "bg-slate-800/90 text-blue-400"
+								: "text-slate-300 hover:bg-slate-800/70",
+						)}
+					>
+						<TerminalSquare className="h-4 w-4" />
+						<span>Output</span>
+					</button>
+					<button
+						type="button"
+						onClick={onReset}
+						className="flex h-12 w-14 flex-col items-center justify-center gap-0.5 rounded-xl text-[10.5px] font-medium text-slate-300 transition-colors hover:bg-slate-800/70"
+					>
+						<RotateCcw className="h-4 w-4" />
+						<span>{labels.reset}</span>
+					</button>
+				</div>
+
+				<div className="flex items-center gap-2">
+					{onShowHint && (
+						<button
+							onClick={onShowHint}
+							aria-label={labels.hint}
+							className="hidden h-12 rounded-2xl border border-slate-600/80 px-4 text-[12px] font-medium text-blue-300 shadow-sm hover:bg-slate-800/70 sm:inline-flex sm:items-center sm:gap-2"
+						>
+							<HelpCircle className="h-4 w-4" />
+							<span>{labels.hint}</span>
+						</button>
+					)}
+					<Button
+						onClick={onRun}
+						className="h-12 min-w-[104px] rounded-2xl bg-blue-500 px-4 text-[14px] font-semibold text-white shadow-[0_14px_34px_-18px_rgba(59,130,246,0.9)] hover:bg-blue-600"
+					>
+						<Play className="mr-2 h-5 w-5 fill-current" />
+						<span>{labels.run}</span>
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+
+	const desktopEditor = (
 		<div className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-slate-800 bg-[#0b1220] shadow-sm">
-			{/* File tab header */}
 			<div className="flex h-11 shrink-0 items-center justify-between border-b border-slate-800/80 bg-[#0b1220] pl-4 pr-2">
 				<div className="flex items-center gap-2">
-					<div className="flex items-center gap-2 border-b-2 border-blue-500 px-1 pb-[10px] pt-[10px] -mb-px">
+					<div className="-mb-px flex items-center gap-2 border-b-2 border-blue-500 px-1 pb-[10px] pt-[10px]">
 						<span className="text-[12.5px] font-medium text-slate-200">
 							main.{fileExt}
 						</span>
@@ -101,7 +210,6 @@ export function CodePanel({
 				</div>
 			</div>
 
-			{/* Editor */}
 			<div className="relative min-h-0 flex-1">
 				<CodeEditor
 					code={code}
@@ -111,14 +219,11 @@ export function CodePanel({
 				/>
 			</div>
 
-			{/* Action bar */}
 			<div className="flex h-12 shrink-0 items-center justify-between border-t border-slate-800/80 bg-[#0b1220] px-3">
 				<div className="flex items-center gap-1">
 					<button
 						type="button"
 						onClick={() => {
-							// Basic format: convert tabs to 2 spaces, strip trailing whitespace,
-							// collapse 3+ blank lines, ensure trailing newline.
 							const formatted = code
 								.replace(/\t/g, "  ")
 								.split("\n")
@@ -189,21 +294,14 @@ export function CodePanel({
 		</div>
 	);
 
-	// Editor-only: parent renders OutputPanel separately
 	if (editorOnly) {
-		return <div className="h-full w-full">{editor}</div>;
+		return <div className="h-full w-full">{desktopEditor}</div>;
 	}
 
-	// Mobile
 	if (isMobile) {
-		return (
-			<div className="relative flex h-full flex-col overflow-hidden bg-slate-50 text-sm">
-				<div className="min-h-0 flex-1 p-2">{editor}</div>
-			</div>
-		);
+		return <div className="h-full w-full">{mobileEditor}</div>;
 	}
 
-	// Fallback desktop: stacked editor + output (used when no module / no sidebar)
 	return (
 		<div className="flex h-full flex-col bg-slate-50">
 			<ResizablePanelGroup direction="vertical" className="flex-1">
@@ -216,7 +314,7 @@ export function CodePanel({
 							collapsible
 							collapsedSize={0}
 						>
-							<div className="h-full p-3 pb-2">{editor}</div>
+							<div className="h-full p-3 pb-2">{desktopEditor}</div>
 						</ResizablePanel>
 						<ResizableHandle />
 					</>

--- a/apps/playground/components/playground/curriculum-sidebar.tsx
+++ b/apps/playground/components/playground/curriculum-sidebar.tsx
@@ -15,7 +15,7 @@ import { ScrollArea } from "@/components/playground/scroll-area";
 import { usePlayground } from "./playground-context";
 import { Button } from "@nuru/ui/components/button";
 
-export function CurriculumSidebar() {
+export function CurriculumSidebar({ isMobile = false }: { isMobile?: boolean }) {
 	const {
 		module,
 		allModules,
@@ -82,6 +82,133 @@ export function CurriculumSidebar() {
 		return n + (completedByModuleSafe[m.id]?.size ?? 0);
 	}, 0);
 	const pctAll = totalAll === 0 ? 0 : Math.round((doneAll / totalAll) * 100);
+
+	const setAllOpen = (value: boolean) => {
+		const next: Record<string, boolean> = {};
+		for (const m of modules) next[m.id] = value;
+		setOpen(next);
+	};
+
+	if (isMobile) {
+		return (
+			<aside className="flex h-full w-full flex-col overflow-hidden rounded-[20px] border border-slate-200 bg-white shadow-sm">
+				<div className="shrink-0 border-b border-slate-200 px-4 py-4">
+					<div className="mb-2 flex items-center justify-between text-[12px] text-slate-500">
+						<span>{pctAll}% complete</span>
+						<span className="font-medium">{doneAll}/{totalAll}</span>
+					</div>
+					<div className="h-2 w-full overflow-hidden rounded-full bg-slate-100">
+						<div
+							className="h-full rounded-full bg-blue-600 transition-all duration-500"
+							style={{ width: `${pctAll}%` }}
+						/>
+					</div>
+					<div className="mt-4 flex items-center justify-between text-[13px] font-medium">
+						<button type="button" onClick={() => setAllOpen(true)} className="text-blue-600">
+							Expand all
+						</button>
+						<button type="button" onClick={() => setAllOpen(false)} className="text-slate-500">
+							Collapse all
+						</button>
+					</div>
+				</div>
+
+				<ScrollArea className="min-h-0 flex-1">
+					<div className="space-y-2 px-3 py-3">
+						{modules.map((m, mi) => {
+							const isCurrent = m.id === module.id;
+							const isOpen = open[m.id] ?? isCurrent;
+							const moduleDone = isCurrent
+								? currentCompleted ?? new Set<number>()
+								: completedByModuleSafe[m.id] ?? new Set<number>();
+							const moduleTotal = m.lessons.length;
+							const moduleDoneCount = moduleDone.size;
+							const prev = modules[mi - 1];
+							const prevDone = prev
+								? (prev.id === module.id
+									? (currentCompleted?.size ?? 0)
+									: (completedByModuleSafe[prev.id]?.size ?? 0))
+								: 0;
+							const isUnlocked =
+								mi === 0 ||
+								isCurrent ||
+								moduleDoneCount > 0 ||
+								(prev && prevDone === prev.lessons.length);
+
+							return (
+								<div key={m.id} className="overflow-hidden rounded-2xl bg-white">
+									<button
+										type="button"
+										onClick={() => setOpen((s) => ({ ...s, [m.id]: !isOpen }))}
+										className={cn(
+											"grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-2xl px-3 py-3 text-left",
+											isCurrent ? "bg-blue-50 text-blue-700" : "text-slate-900 hover:bg-slate-50",
+											!isUnlocked && "opacity-70",
+										)}
+									>
+										<span className="min-w-0">
+											<span className="block truncate text-[15px] font-semibold">
+												{m.slug || m.title[lang] || m.title.sw}
+											</span>
+											<span className="mt-1 block text-[12px] font-medium text-slate-500">
+												{moduleDoneCount}/{moduleTotal} · {moduleTotal ? Math.round((moduleDoneCount / moduleTotal) * 100) : 0}%
+											</span>
+										</span>
+										<span className="flex shrink-0 items-center gap-2">
+											{!isUnlocked && <Lock className="h-3.5 w-3.5 text-slate-400" />}
+											<ChevronDown className={cn("h-5 w-5 text-slate-400 transition-transform", !isOpen && "-rotate-90")} />
+										</span>
+									</button>
+
+									{isOpen && (
+										<ul className="space-y-1 px-1 py-1">
+											{m.lessons.map((lesson, i) => {
+												const isActive = isCurrent && i === currentLessonIndex;
+												const isDone = moduleDone.has(i);
+												return (
+													<li key={lesson.id}>
+														<button
+															disabled={!isUnlocked}
+															onClick={() => {
+																setViewMode("lesson");
+																if (isCurrent) {
+																	onLessonChange?.(i);
+																} else {
+																	router.push(`/${lang}/anza/${m.slug}/${lesson.slug}`);
+																}
+															}}
+															className={cn(
+																"grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-2xl px-3 py-3 text-left text-[14px] transition-colors disabled:cursor-not-allowed",
+																isActive ? "bg-blue-50 text-blue-700" : "text-slate-700 hover:bg-slate-50",
+															)}
+														>
+															<span className={cn("flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[12px] font-semibold", isActive || isDone ? "bg-blue-600 text-white" : "bg-slate-100 text-slate-500")}>
+																{isDone ? <CheckCircle2 className="h-4 w-4" /> : i + 1}
+															</span>
+															<span className="min-w-0 truncate">{lesson.title[lang] || lesson.title.sw}</span>
+															<span className="shrink-0">
+																{isActive ? (
+																	<CircleDot className="h-5 w-5 text-blue-500" />
+																) : !isUnlocked ? (
+																	<Lock className="h-3.5 w-3.5 text-slate-300" />
+																) : (
+																	<span className="block h-4 w-4 rounded-full border border-slate-300" />
+																)}
+															</span>
+														</button>
+													</li>
+												);
+											})}
+										</ul>
+									)}
+								</div>
+							);
+						})}
+					</div>
+				</ScrollArea>
+			</aside>
+		);
+	}
 
 	return (
 		<aside className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">

--- a/apps/playground/components/playground/lesson-panel.tsx
+++ b/apps/playground/components/playground/lesson-panel.tsx
@@ -346,100 +346,94 @@ export function LessonPanel({
 		);
 	}
 
-	// Mobile: collapsible panel inside a resizable pane
+	// Mobile: white lesson sheet with collapsible content.
 	return (
-		<div className={cn("font-mono","bg-card flex h-full flex-col overflow-hidden")}>
-			<div
-				role="button"
-				tabIndex={0}
-				onClick={onToggle}
-				onKeyDown={(e) => {
-					if (e.key === "Enter" || e.key === " ") {
-						onToggle?.();
-					}
-				}}
-				className="border-border bg-muted/30 hover:bg-muted/50 flex w-full shrink-0 cursor-pointer items-center justify-between border-b px-4 py-3 text-left transition-colors"
-			>
-				<div className="flex items-center gap-2.5 truncate">
-					<h1 className="text-foreground truncate text-sm font-bold tracking-tight">
+		<div className="flex h-full flex-col overflow-hidden rounded-[20px] border border-slate-200 bg-white text-slate-900 shadow-sm">
+			<div className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+				<div className="min-w-0 text-[12px] text-slate-500">
+					Step {currentLessonIndex + 1} of {module.lessons.length}
+					<span className="mx-2 text-slate-300">•</span>
+					{labels.lesson}
+					<div className="mt-1 truncate text-[15px] font-semibold text-slate-900">
 						{lesson.title[lang] || lesson.title.sw}
-					</h1>
+					</div>
 				</div>
-				<div className="flex shrink-0 items-center gap-3">
-					{isCompleted ? (
-						<CheckCircle2 className="h-4 w-4 text-green-500" />
-					) : (
-						<div className="bg-muted-foreground/40 h-1.5 w-1.5 animate-pulse rounded-full" />
-					)}
-					<ChevronDown
-						className={cn(
-							"text-muted-foreground h-4 w-4 shrink-0 transition-transform duration-300",
-							expanded && "rotate-180",
-						)}
-					/>
-				</div>
+				<button
+					type="button"
+					onClick={onToggle}
+					className="shrink-0 rounded-full p-1.5 text-slate-500 transition-transform hover:bg-slate-100 hover:text-slate-900"
+					aria-label={expanded ? "Collapse lesson" : "Expand lesson"}
+				>
+					<ChevronDown className={cn("h-5 w-5 transition-transform", expanded && "rotate-180")} />
+				</button>
 			</div>
+
 			{expanded && (
 				<ScrollArea className="flex-1 [&>div>div]:h-full">
-					<div className="flex min-h-full w-full min-w-0 flex-col px-4 pt-4 pb-6 text-sm">
+					<div className="flex min-h-full w-full min-w-0 flex-col px-4 pb-5 text-sm">
 						<div className="flex-1">
-							<div
-								key={currentLessonIndex}
-								className="animate-in fade-in slide-in-from-bottom-2 duration-300"
-							>
-								<div className="text-muted-foreground/90 mb-6 leading-relaxed">
+							<div key={currentLessonIndex} className="animate-in fade-in slide-in-from-bottom-2 duration-300">
+								<div className="mb-5">
+									<h1 className="text-[20px] font-semibold leading-tight text-slate-950">
+										{lesson.title[lang] || lesson.title.sw}
+									</h1>
+									<div className="mt-4 max-w-[180px]">
+										<div className="mb-2 text-[12px] text-slate-500">
+											Step {currentLessonIndex + 1} of {module.lessons.length}
+										</div>
+										<div className="h-2 overflow-hidden rounded-full bg-slate-100">
+											<div className="h-full rounded-full bg-blue-500" style={{ width: `${((currentLessonIndex + 1) / module.lessons.length) * 100}%` }} />
+										</div>
+									</div>
+								</div>
+
+								<div className="mb-5 text-[14px] leading-7 text-slate-700">
 									<Markdown
 										components={{
 											code(props) {
 												const { children, className, ...rest } = props;
 												const match = /language-(\w+)/.exec(className || "");
 												if (match) {
-													const { cleanedCode, highlights } = parseHighlights(
-														String(children).replace(/\n$/, ""),
-													);
+													const { cleanedCode, highlights } = parseHighlights(String(children).replace(/\n$/, ""));
 													return (
-														<div className="not-prose border-border bg-muted/30 my-4 overflow-hidden rounded-xl border">
-															<CodeEditor
-																code={cleanedCode}
-																highlights={highlights}
-																readOnly
-																extensions={extensions}
-															/>
+												<div className="not-prose my-5 overflow-hidden rounded-2xl border border-slate-800 bg-[#071225]">
+															<CodeEditor code={cleanedCode} highlights={highlights} readOnly extensions={extensions} />
 														</div>
 													);
 												}
 												return (
-													<code
-														className="bg-muted text-foreground rounded px-1.5 py-0.5 font-mono text-[12px]"
-														{...rest}
-													>
+										<code className="rounded-md bg-blue-50 px-1.5 py-0.5 font-mono text-[0.9em] text-blue-700" {...rest}>
 														{children}
 													</code>
 												);
 											},
+											p: ({ children }) => <p className="mb-4 last:mb-0">{children}</p>,
 										}}
 									>
 										{lesson.description[lang] || lesson.description.sw}
 									</Markdown>
 								</div>
+
 								{lesson.task && (
-									<div className="mb-6 overflow-hidden rounded-xl border border-yellow-500/20 bg-yellow-500/3 shadow-xs">
-										<div className="flex items-center justify-between border-b border-yellow-500/10 bg-yellow-500/10 px-3 py-2">
-											<h4 className="flex items-center gap-1.5 text-[10px] font-black tracking-widest text-yellow-600 uppercase dark:text-yellow-500">
-												<Lightbulb className="h-3 w-3" />
-												{labels.yourTask}
-											</h4>
-										</div>
-										<div className="p-4">
-											<p className="text-foreground/90 text-[13px] leading-relaxed italic">
-												{lesson.task[lang] || lesson.task.sw}
-											</p>
+									<div className="mb-5 overflow-hidden rounded-2xl border border-amber-200 bg-amber-50 shadow-sm">
+										<div className="flex items-start gap-3 px-4 py-4">
+											<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-amber-200 bg-white text-amber-500">
+												<Lightbulb className="h-5 w-5" />
+											</div>
+											<div className="min-w-0 flex-1">
+												<h4 className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-600">
+													{labels.yourTask}
+												</h4>
+												<p className="text-[14px] leading-7 text-slate-700">
+													{lesson.task[lang] || lesson.task.sw}
+												</p>
+											</div>
 										</div>
 									</div>
 								)}
 
 								{testCasesSection}
-							</div>{" "}
+							</div>
 						</div>
 						{navigation}
 					</div>

--- a/apps/playground/components/playground/merged-view.tsx
+++ b/apps/playground/components/playground/merged-view.tsx
@@ -33,6 +33,7 @@ import { ScrollArea } from "@/components/playground/scroll-area";
 import { usePlayground } from "./playground-context";
 import { AuthContext } from "@/components/providers/auth-provider";
 import type { Module } from "@/types/playground";
+import { cn } from "@nuru/ui/lib/utils";
 
 /* ------------ shared completion hook ------------ */
 
@@ -60,7 +61,7 @@ function useCompletedMap(modules: Module[] | undefined) {
 
 /* ------------ shell ------------ */
 
-export function MergedView() {
+export function MergedView({ isMobile = false }: { isMobile?: boolean }) {
 	const {
 		viewMode,
 		setViewMode,
@@ -74,7 +75,13 @@ export function MergedView() {
 	const crumbTail = viewMode === "lesson-map" ? "Curriculum Map" : "My Progress";
 
 	return (
-		<div className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+		<div
+			className={cn(
+				"flex h-full w-full flex-col overflow-hidden bg-white",
+				isMobile ? "rounded-[20px] border border-slate-200 shadow-sm" : "rounded-2xl border border-slate-200 shadow-sm",
+			)}
+		>
+			{!isMobile && (
 			<div className="flex shrink-0 items-center justify-between gap-3 border-b border-slate-200 bg-white px-5 py-3">
 				<nav className="flex min-w-0 items-center gap-1.5 text-[12px] text-slate-500">
 					<button onClick={() => setViewMode("lesson")} className="hover:text-slate-900">
@@ -96,7 +103,8 @@ export function MergedView() {
 					Back to lesson
 				</Button>
 			</div>
-			<ScrollArea className="flex-1 bg-slate-50">
+			)}
+			<ScrollArea className={cn("flex-1", isMobile ? "bg-white" : "bg-slate-50")}>
 				{viewMode === "lesson-map" ? <LessonMapView /> : <ProgressView />}
 			</ScrollArea>
 		</div>

--- a/apps/playground/components/playground/output-panel.tsx
+++ b/apps/playground/components/playground/output-panel.tsx
@@ -6,8 +6,8 @@ import {
 	CheckCircle2,
 	XCircle,
 	AlertCircle,
-	Lock,
 	MinusCircle,
+	ChevronDown,
 } from "lucide-react";
 import { ScrollArea } from "@/components/playground/scroll-area";
 import { cn } from "@nuru/ui/lib/utils";
@@ -16,46 +16,187 @@ import { getRenderer } from "./renderers/registry";
 
 interface OutputPanelProps {
 	showToolbar?: boolean;
+	isMobile?: boolean;
 }
 
-/**
- * Output + Tests panel matching the mockups.
- * - White card surface with two tabs (Output, Tests)
- * - Output tab: dark terminal with copy/clear actions
- * - Tests tab: summary row + per-test pass/fail rows
- * - When tests fail, also shows a friendly error banner above
- */
-export function OutputPanel({ showToolbar = true }: OutputPanelProps) {
+export function OutputPanel({ showToolbar = true, isMobile = false }: OutputPanelProps) {
 	const {
 		module,
 		state: { output, testErrors, testResults },
 		labels,
+		isCurrentLessonCompleted,
 	} = usePlayground();
 
 	const [tab, setTab] = useState<"output" | "tests">("output");
-
 	const rendererId = module?.panels?.renderer?.type || "standard-terminal";
 	const RendererComponent = getRenderer(rendererId);
-
-	// Aggregate test info from current lesson + results
-	const lesson =
-		module && module.lessons && typeof module === "object"
-			? undefined
-			: undefined; // tests visible via testResults below
-
 	const tests = Object.entries(testResults || {});
 	const passedCount = tests.filter(([, r]) => r.passed).length;
 	const totalTests = tests.length;
 	const allPassed = totalTests > 0 && passedCount === totalTests;
-	const anyFailed = tests.some(([, r]) => r.passed === false);
 
 	const handleCopy = () => {
 		if (output) navigator.clipboard?.writeText(output).catch(() => {});
 	};
 
+	if (isMobile) {
+		return (
+			<div className="flex h-full w-full flex-col overflow-hidden rounded-[20px] border border-slate-200 bg-white text-slate-900 shadow-sm">
+				<div className="flex shrink-0 items-center justify-between border-b border-slate-200 px-4 py-3">
+					<h2 className="text-[15px] font-semibold text-slate-900">Output</h2>
+					{isCurrentLessonCompleted && (
+						<div className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-1 text-[12px] font-medium text-emerald-600">
+							<CheckCircle2 className="h-3.5 w-3.5" />
+							<span>Passed</span>
+						</div>
+					)}
+				</div>
+
+				<div className="px-4 py-3">
+					<div className="grid grid-cols-2 rounded-2xl border border-slate-200 bg-slate-50 p-1">
+						{(["output", "tests"] as const).map((t) => (
+							<button
+								key={t}
+								onClick={() => setTab(t)}
+								className={cn(
+									"rounded-[14px] px-4 py-2.5 text-[13px] font-medium transition-all",
+									tab === t
+										? "bg-white text-blue-600 shadow-sm"
+										: "text-slate-500 hover:text-slate-700",
+								)}
+							>
+								{t === "output" ? "Output" : "Tests"}
+							</button>
+						))}
+					</div>
+				</div>
+
+				<div className="min-h-0 flex-1">
+					{tab === "output" ? (
+						<div className="flex h-full flex-col px-4 pb-4">
+							{showToolbar && (
+								<div className="mb-3 flex justify-end gap-1">
+									<button
+										onClick={handleCopy}
+										aria-label="Copy output"
+										className="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-100"
+									>
+										<Copy className="h-4 w-4" />
+									</button>
+									<button
+										aria-label="Clear output"
+										className="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-100"
+									>
+										<Trash2 className="h-4 w-4" />
+									</button>
+								</div>
+							)}
+							<div className="min-h-0 flex-1 overflow-hidden rounded-2xl border border-slate-800 bg-[#071225]">
+								<ScrollArea className="h-full">
+									<div className="px-5 py-4">
+										{rendererId === "standard-terminal" ? (
+											output ? (
+										<pre className="whitespace-pre-wrap font-mono text-[13px] leading-7 text-slate-100">
+													{output.split("\n").map((line, i) => {
+														const isError =
+															line.toLowerCase().includes("error:") ||
+															line.toLowerCase().includes("hitilafu:");
+														return (
+															<span key={i} className={cn("block", isError && "text-red-400")}>
+																{line}
+															</span>
+														);
+													})}
+												</pre>
+											) : (
+												<p className="font-mono text-[13px] italic text-slate-500">
+													{labels.outputPlaceholder}
+												</p>
+											)
+										) : RendererComponent ? (
+											<RendererComponent />
+										) : (
+											<p className="font-mono text-[12px] text-slate-500">
+												Renderer "{rendererId}" not found
+											</p>
+										)}
+									</div>
+								</ScrollArea>
+							</div>
+						</div>
+					) : (
+						<ScrollArea className="h-full px-4 pb-4">
+							<div className="space-y-4 pb-3">
+								<div className="flex items-center justify-between pt-1 text-[13px]">
+									<span className={cn("font-medium", allPassed ? "text-emerald-600" : "text-slate-600")}>
+										{passedCount} / {totalTests || 0} tests passed
+									</span>
+									<span className="text-slate-500">
+										{allPassed ? "All tests passed! 🎉" : "Keep going"}
+									</span>
+								</div>
+
+								{testErrors && testErrors.length > 0 && (
+									<div className="rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3">
+										<div className="mb-1 flex items-center gap-2 text-[13px] font-semibold text-red-300">
+											<AlertCircle className="h-4 w-4" />
+											{labels.error}
+										</div>
+										<ul className="space-y-1 text-[12.5px] text-red-200/90">
+											{testErrors.map((e, i) => (
+												<li key={i}>{e}</li>
+											))}
+										</ul>
+									</div>
+								)}
+
+								<ul className="space-y-3">
+									{tests.length === 0 && (
+									<li className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-5 text-center text-[13px] text-slate-500">
+											Run the code to see test results.
+										</li>
+									)}
+									{tests.map(([id, r], i) => (
+										<li
+											key={id}
+										className="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-4"
+										>
+											<div className="flex min-w-0 items-center gap-3">
+												<span className="shrink-0">
+													{r.passed ? (
+														<CheckCircle2 className="h-6 w-6 text-emerald-400" />
+													) : r.passed === false ? (
+														<XCircle className="h-6 w-6 text-red-400" />
+													) : (
+														<MinusCircle className="h-6 w-6 text-slate-500" />
+													)}
+												</span>
+												<div className="min-w-0">
+											<div className="text-[13px] font-medium text-slate-900">Test {i + 1}</div>
+													<div className="truncate text-[12px] text-slate-400">
+														{r.error || "Expected output"}
+													</div>
+												</div>
+											</div>
+											<div className="flex items-center gap-3">
+												<span className={cn("text-[14px] font-medium", r.passed ? "text-emerald-400" : r.passed === false ? "text-red-400" : "text-slate-500")}>
+													{r.passed ? labels.testPassed : r.passed === false ? labels.testFailed : "—"}
+												</span>
+												<ChevronDown className="h-4 w-4 text-slate-500" />
+											</div>
+										</li>
+									))}
+								</ul>
+							</div>
+						</ScrollArea>
+					)}
+				</div>
+			</div>
+		);
+	}
+
 	return (
 		<div className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-			{/* Tabs header */}
 			<div className="flex shrink-0 items-center justify-between border-b border-slate-200 px-4">
 				<div className="flex items-center gap-1">
 					{(["output", "tests"] as const).map((t) => (
@@ -64,9 +205,7 @@ export function OutputPanel({ showToolbar = true }: OutputPanelProps) {
 							onClick={() => setTab(t)}
 							className={cn(
 								"relative px-2 py-3 text-[13px] font-semibold capitalize transition-colors",
-								tab === t
-									? "text-blue-600"
-									: "text-slate-500 hover:text-slate-700",
+								tab === t ? "text-blue-600" : "text-slate-500 hover:text-slate-700",
 							)}
 						>
 							{t === "output" ? "Output" : "Tests"}
@@ -78,16 +217,12 @@ export function OutputPanel({ showToolbar = true }: OutputPanelProps) {
 				</div>
 			</div>
 
-			{/* Body */}
 			<div className="flex min-h-0 flex-1 flex-col">
-				{/* Error banner (visible from any tab when test errors exist) */}
 				{testErrors && testErrors.length > 0 && (
 					<div className="m-4 mb-0 flex items-start gap-3 rounded-xl border border-red-200 bg-red-50 px-4 py-3">
 						<AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
 						<div className="min-w-0 flex-1">
-							<div className="mb-1 text-[13px] font-semibold text-red-700">
-								{labels.error}
-							</div>
+							<div className="mb-1 text-[13px] font-semibold text-red-700">{labels.error}</div>
 							<ul className="space-y-1 text-[12.5px] leading-relaxed text-red-700/90">
 								{testErrors.map((e, i) => (
 									<li key={i}>{e}</li>
@@ -99,54 +234,46 @@ export function OutputPanel({ showToolbar = true }: OutputPanelProps) {
 
 				{tab === "output" ? (
 					<div className="m-4 flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-slate-800 bg-[#0b1220]">
-						<div className="flex items-center justify-end gap-1 px-2 py-1.5">
-							<button
-								onClick={handleCopy}
-								aria-label="Copy output"
-								className="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-200"
-							>
-								<Copy className="h-3.5 w-3.5" />
-							</button>
-							<button
-								aria-label="Clear output"
-								className="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-200"
-							>
-								<Trash2 className="h-3.5 w-3.5" />
-							</button>
-						</div>
+						{showToolbar && (
+							<div className="flex items-center justify-end gap-1 px-2 py-1.5">
+								<button
+									onClick={handleCopy}
+									aria-label="Copy output"
+									className="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-200"
+								>
+									<Copy className="h-3.5 w-3.5" />
+								</button>
+								<button
+									aria-label="Clear output"
+									className="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-200"
+								>
+									<Trash2 className="h-3.5 w-3.5" />
+								</button>
+							</div>
+						)}
 						<ScrollArea className="flex-1">
 							<div className="px-4 pb-4">
 								{rendererId === "standard-terminal" ? (
 									output ? (
-										<pre className="font-mono text-[12.5px] leading-relaxed text-slate-100 whitespace-pre-wrap">
+										<pre className="whitespace-pre-wrap font-mono text-[12.5px] leading-relaxed text-slate-100">
 											{output.split("\n").map((line, i) => {
 												const isError =
 													line.toLowerCase().includes("error:") ||
 													line.toLowerCase().includes("hitilafu:");
 												return (
-													<span
-														key={i}
-														className={cn(
-															"block",
-															isError && "text-red-400",
-														)}
-													>
+													<span key={i} className={cn("block", isError && "text-red-400")}>
 														{line}
 													</span>
 												);
 											})}
 										</pre>
 									) : (
-										<p className="font-mono text-[12px] italic text-slate-500">
-											{labels.outputPlaceholder}
-										</p>
+										<p className="font-mono text-[12px] italic text-slate-500">{labels.outputPlaceholder}</p>
 									)
 								) : RendererComponent ? (
 									<RendererComponent />
 								) : (
-									<p className="font-mono text-[12px] text-slate-500">
-										Renderer "{rendererId}" not found
-									</p>
+									<p className="font-mono text-[12px] text-slate-500">Renderer "{rendererId}" not found</p>
 								)}
 							</div>
 						</ScrollArea>
@@ -157,23 +284,9 @@ export function OutputPanel({ showToolbar = true }: OutputPanelProps) {
 							{totalTests > 0 && (
 								<div className="mb-3 flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
 									<div className="flex items-center gap-2 text-[13px] font-semibold">
-										{allPassed ? (
-											<>
-												<span>All tests passed!</span>
-												<span aria-hidden>🎉</span>
-											</>
-										) : (
-											<span className="text-slate-700">
-												{passedCount} of {totalTests} tests passed
-											</span>
-										)}
+										{allPassed ? <><span>All tests passed!</span><span aria-hidden>🎉</span></> : <span className="text-slate-700">{passedCount} of {totalTests} tests passed</span>}
 									</div>
-									<div
-										className={cn(
-											"text-[12px] font-semibold",
-											allPassed ? "text-emerald-600" : "text-slate-500",
-										)}
-									>
+									<div className={cn("text-[12px] font-semibold", allPassed ? "text-emerald-600" : "text-slate-500")}>
 										{passedCount} / {totalTests} tests passed
 									</div>
 								</div>
@@ -190,49 +303,20 @@ export function OutputPanel({ showToolbar = true }: OutputPanelProps) {
 										key={id}
 										className={cn(
 											"flex items-center justify-between gap-3 rounded-xl border px-4 py-3 text-[13px]",
-											r.passed
-												? "border-emerald-200 bg-emerald-50/50"
-												: r.passed === false
-													? "border-red-200 bg-red-50/50"
-													: "border-slate-200 bg-white",
+											r.passed ? "border-emerald-200 bg-emerald-50/50" : r.passed === false ? "border-red-200 bg-red-50/50" : "border-slate-200 bg-white",
 										)}
 									>
 										<div className="flex min-w-0 items-center gap-3">
 											<span className="shrink-0">
-												{r.passed ? (
-													<CheckCircle2 className="h-4 w-4 text-emerald-500" />
-												) : r.passed === false ? (
-													<XCircle className="h-4 w-4 text-red-500" />
-												) : (
-													<MinusCircle className="h-4 w-4 text-slate-300" />
-												)}
+												{r.passed ? <CheckCircle2 className="h-4 w-4 text-emerald-500" /> : r.passed === false ? <XCircle className="h-4 w-4 text-red-500" /> : <MinusCircle className="h-4 w-4 text-slate-300" />}
 											</span>
 											<div className="min-w-0">
-												<div className="font-semibold text-slate-800">
-													Test {i + 1}
-												</div>
-												{r.error && (
-													<div className="truncate text-[12px] text-red-600">
-														{r.error}
-													</div>
-												)}
+												<div className="font-semibold text-slate-800">Test {i + 1}</div>
+												{r.error && <div className="truncate text-[12px] text-red-600">{r.error}</div>}
 											</div>
 										</div>
-										<span
-											className={cn(
-												"shrink-0 text-[12px] font-semibold",
-												r.passed
-													? "text-emerald-600"
-													: r.passed === false
-														? "text-red-600"
-														: "text-slate-400",
-											)}
-										>
-											{r.passed
-												? labels.testPassed
-												: r.passed === false
-													? labels.testFailed
-													: "—"}
+										<span className={cn("shrink-0 text-[12px] font-semibold", r.passed ? "text-emerald-600" : r.passed === false ? "text-red-600" : "text-slate-400")}>
+											{r.passed ? labels.testPassed : r.passed === false ? labels.testFailed : "—"}
 										</span>
 									</li>
 								))}

--- a/apps/playground/components/playground/playground-context.tsx
+++ b/apps/playground/components/playground/playground-context.tsx
@@ -3,7 +3,13 @@
 import { createContext, useContext, ReactNode } from "react";
 import { PlaygroundProps } from "@/types/playground";
 
-export type PlaygroundViewMode = "lesson" | "lesson-map" | "progress";
+export type PlaygroundViewMode =
+	| "lesson"
+	| "code"
+	| "output"
+	| "lesson-map"
+	| "progress"
+	| "curriculum";
 
 export type PlaygroundContextValue = PlaygroundProps & {
 	isCurrentLessonCompleted?: boolean;

--- a/apps/playground/components/playground/playground.tsx
+++ b/apps/playground/components/playground/playground.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useRef, useState, useEffect } from "react";
-import type { ImperativePanelHandle } from "react-resizable-panels";
+import { useState, useEffect } from "react";
 import { LessonPanel } from "./lesson-panel";
 import { LessonContentPanel } from "./lesson-content-panel";
 import { CurriculumSidebar } from "./curriculum-sidebar";
@@ -15,12 +14,18 @@ import {
 } from "@/components/playground/resizable";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { PlaygroundProps } from "@/types/playground";
-import { CheckCircle2, BookOpen, ChevronDown } from "lucide-react";
-import { Drawer } from "@nuru/ui/components/drawer";
-import { DrawerContent } from "@nuru/ui/components/drawer";
-import { DrawerTrigger } from "@nuru/ui/components/drawer";
-import { DrawerTitle } from "@nuru/ui/components/drawer";
-import { DrawerDescription } from "@nuru/ui/components/drawer";
+import { AppLogo } from "@nuru/ui/components/app-logo";
+import {
+	BarChart3,
+	BookOpen,
+	ChevronLeft,
+	Code2,
+	ListTree,
+	Map,
+	TerminalSquare,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { cn } from "@nuru/ui/lib/utils";
 import {
 	PlaygroundProvider,
 	PlaygroundContextValue,
@@ -30,6 +35,7 @@ import {
 
 export function Playground(props: PlaygroundProps) {
 	const { module, state, actions, labels, lang } = props;
+	const router = useRouter();
 	const isMobileRaw = useIsMobile();
 	const [mounted, setMounted] = useState(false);
 	useEffect(() => {
@@ -39,14 +45,12 @@ export function Playground(props: PlaygroundProps) {
 	// the server HTML and the first client render match. Switch to the mobile
 	// tree only AFTER hydration.
 	const isMobile = mounted && isMobileRaw;
-	const [moduleDrawerOpen, setModuleDrawerOpen] = useState(false);
-
-	const bottomPanelRef = useRef<ImperativePanelHandle>(null);
 
 	const [activeMaximizedPanel, setActiveMaximizedPanel] = useState<
 		string | null
 	>(null);
 	const [viewMode, setViewMode] = useState<PlaygroundViewMode>("lesson");
+	const [lessonExpanded, setLessonExpanded] = useState(true);
 
 	// Return to lesson view whenever the lesson changes (e.g. user clicked a node).
 	useEffect(() => {
@@ -64,17 +68,9 @@ export function Playground(props: PlaygroundProps) {
 		}
 	}, [isMobile, module?.id, module?.panels]);
 
-	useEffect(() => {
-		if (isMobile && module && state.currentLessonIndex === 0) {
-			const timer = setTimeout(() => setModuleDrawerOpen(true), 500);
-			return () => clearTimeout(timer);
-		}
-	}, [isMobile, module?.id, state.currentLessonIndex]);
-
 	const currentLesson = module?.lessons[state.currentLessonIndex ?? 0];
 	const isCurrentLessonCompleted = module
-		? (state.completedLessonIndices?.has(state.currentLessonIndex ?? 0) ??
-			false)
+		? (state.completedLessonIndices?.has(state.currentLessonIndex ?? 0) ?? false)
 		: undefined;
 	const isLastLesson = module
 		? state.currentLessonIndex === module.lessons.length - 1
@@ -92,8 +88,7 @@ export function Playground(props: PlaygroundProps) {
 	const handleRun = () => {
 		actions.onRun();
 		if (isMobile) {
-			bottomPanelRef.current?.expand();
-			bottomPanelRef.current?.resize(20);
+			setViewMode("output");
 		}
 	};
 
@@ -118,70 +113,108 @@ export function Playground(props: PlaygroundProps) {
 
 	};
 
-	// ---------- Mobile (unchanged behavior, light surfaces) ----------
+	// ---------- Mobile: mockup-driven shell; desktop untouched ----------
 	if (isMobile) {
+		const progressWidth = module
+			? `${(((state.currentLessonIndex ?? 0) + 1) / module.lessons.length) * 100}%`
+			: "0%";
+		const mobileTabs: Array<{
+			mode: PlaygroundViewMode;
+			label: string;
+			Icon: typeof BookOpen;
+		}> = [
+			{ mode: "lesson", label: "Lesson", Icon: BookOpen },
+			{ mode: "code", label: "Code", Icon: Code2 },
+			{ mode: "output", label: "Output", Icon: TerminalSquare },
+			{ mode: "lesson-map", label: "Map", Icon: Map },
+			{ mode: "progress", label: "Progress", Icon: BarChart3 },
+			{ mode: "curriculum", label: "Modules", Icon: ListTree },
+		];
+
 		return (
 			<PlaygroundProvider value={contextValue}>
-				<div className="relative flex max-h-full flex-1 flex-col overflow-hidden bg-slate-50">
-					{module && (
-						<Drawer open={moduleDrawerOpen} onOpenChange={setModuleDrawerOpen}>
-							<DrawerTrigger asChild>
-								<button className="z-10 flex w-full shrink-0 items-center justify-between border-b border-slate-200 bg-white px-4 py-3 text-left shadow-sm">
-									<div className="mr-4 flex min-w-0 flex-1 items-center gap-3">
-										<div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50">
-											<BookOpen className="h-4 w-4 text-blue-600" />
-										</div>
-										<div className="flex min-w-0 flex-col">
-											<span className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">
-												{labels.lesson} {(state.currentLessonIndex ?? 0) + 1}
-											</span>
-											<h1 className="truncate text-sm font-semibold text-slate-900">
-												{currentLesson?.title[lang] || currentLesson?.title.sw}
-											</h1>
-										</div>
-									</div>
-									<div className="flex shrink-0 items-center gap-2">
-										{isCurrentLessonCompleted ? (
-											<CheckCircle2 className="h-5 w-5 text-emerald-500" />
-										) : (
-											<div className="h-2 w-2 rounded-full bg-slate-300" />
-										)}
-										<ChevronDown className="h-4 w-4 text-slate-400" />
-									</div>
+				<div className="relative flex h-full max-h-full flex-1 flex-col overflow-hidden bg-white">
+					<div className="shrink-0 border-b border-slate-200 bg-white px-4 pb-3 pt-4">
+						<div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4">
+							<div className="flex min-w-0 items-center gap-3">
+								<button
+									type="button"
+									onClick={() => router.push(`/${lang}/anza`)}
+									className="shrink-0 rounded-full p-1.5 text-slate-500 hover:bg-slate-100 hover:text-slate-900"
+									aria-label="Back"
+								>
+									<ChevronLeft className="h-5 w-5" />
 								</button>
-							</DrawerTrigger>
-							<DrawerContent className="max-h-[85vh]">
-								<DrawerTitle className="sr-only">
-									{currentLesson?.title[lang] || currentLesson?.title.sw}
-								</DrawerTitle>
-								<DrawerDescription className="sr-only">
-									Lesson instructions
-								</DrawerDescription>
-								<div className="h-full overflow-y-auto px-4 pt-2 pb-8">
-									<LessonPanel collapsible={false} expanded={true} />
+								<AppLogo size={30} className="shrink-0" />
+								<div className="min-w-0">
+									<div className="truncate text-[17px] font-semibold text-slate-900">Nuru</div>
 								</div>
-							</DrawerContent>
-						</Drawer>
-					)}
-
-					<div className="relative flex-1 overflow-hidden">
-						<ResizablePanelGroup direction="vertical">
-							<ResizablePanel defaultSize={80} minSize={20}>
-								<CodePanel onRun={handleRun} isMobile />
-							</ResizablePanel>
-							<ResizableHandle withHandle />
-							<ResizablePanel
-								ref={bottomPanelRef}
-								defaultSize={20}
-								minSize={10}
-								collapsible
-								collapsedSize={0}
+							</div>
+							<button
+								type="button"
+								onClick={() => setViewMode(viewMode === "lesson" ? "code" : "lesson")}
+								className="inline-flex h-10 shrink-0 items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 text-[13px] font-medium text-slate-700"
 							>
-								<div className="h-full bg-slate-50 p-2">
-									<OutputPanel showToolbar={false} />
+								{viewMode === "lesson" ? (
+									<Code2 className="h-4 w-4 text-slate-600" />
+								) : (
+									<BookOpen className="h-4 w-4 text-slate-600" />
+								)}
+								<span>{viewMode === "lesson" ? "Code" : "Lesson"}</span>
+							</button>
+						</div>
+
+						{module && (
+							<div className="mt-4 grid grid-cols-[minmax(0,1fr)_auto] items-end gap-4">
+								<div className="min-w-0">
+									<div className="mb-2 text-[12px] text-slate-500">
+										Step {(state.currentLessonIndex ?? 0) + 1} of {module.lessons.length}
+									</div>
+									<div className="h-2 overflow-hidden rounded-full bg-slate-200">
+										<div className="h-full rounded-full bg-blue-500" style={{ width: progressWidth }} />
+									</div>
 								</div>
-							</ResizablePanel>
-						</ResizablePanelGroup>
+								<div className="text-right text-[12px] text-slate-400">
+									{isCurrentLessonCompleted ? "Completed" : "In progress"}
+								</div>
+							</div>
+						)}
+
+						<div className="mt-3 flex gap-2 overflow-x-auto pb-1 no-scrollbar">
+							{mobileTabs.map(({ mode, label, Icon }) => (
+								<button
+									key={mode}
+									type="button"
+									onClick={() => setViewMode(mode)}
+									className={cn(
+										"inline-flex h-9 shrink-0 items-center gap-1.5 rounded-full border px-3 text-[12px] font-semibold transition-colors",
+										viewMode === mode
+											? "border-blue-600 bg-blue-600 text-white"
+											: "border-slate-200 bg-white text-slate-600 hover:bg-slate-50",
+									)}
+								>
+									<Icon className="h-3.5 w-3.5" />
+									<span>{label}</span>
+								</button>
+							))}
+						</div>
+					</div>
+
+					<div className="min-h-0 flex-1 overflow-hidden bg-white px-3 pb-3 pt-3">
+						<div className="h-full min-h-0 overflow-hidden">
+							{viewMode === "lesson" && (
+								<LessonPanel
+									collapsible
+									expanded={lessonExpanded}
+									onToggle={() => setLessonExpanded((value) => !value)}
+								/>
+							)}
+							{viewMode === "code" && <CodePanel onRun={handleRun} isMobile />}
+							{viewMode === "output" && <OutputPanel isMobile />}
+							{viewMode === "lesson-map" && <MergedView isMobile />}
+							{viewMode === "progress" && <MergedView isMobile />}
+							{viewMode === "curriculum" && <CurriculumSidebar isMobile />}
+						</div>
 					</div>
 				</div>
 			</PlaygroundProvider>
@@ -190,7 +223,7 @@ export function Playground(props: PlaygroundProps) {
 
 	// ---------- Desktop: 3-column shell matching the mockups ----------
 	const showSidebar = !!module;
-	const isMerged = showSidebar && viewMode !== "lesson";
+	const isMerged = showSidebar && (viewMode === "lesson-map" || viewMode === "progress");
 
 	return (
 		<PlaygroundProvider value={contextValue}>


### PR DESCRIPTION
## Summary

This PR improves the mobile experience of the Nuru Playground.

The update focuses on making the Playground usable on small screens by giving learners clear access to the lesson, code editor, output, lesson map, progress, and modules from a mobile friendly layout.

## Changes

* Improved the mobile Playground workspace layout
* Added a clearer mobile structure for switching between Lesson, Code, Output, Map, Progress, and Modules
* Kept the mobile background light and aligned with the new UI direction
* Improved access to lesson content on mobile
* Improved access to the code editor for mobile coding
* Improved access to output and tests on mobile
* Restored visibility for important Playground sections that were difficult to reach on mobile
* Preserved the existing desktop Playground layout

## Why

The previous mobile layout made it difficult to use the core Playground experience. Learners could not easily move between reading instructions, writing code, viewing output, checking the lesson map, and tracking progress.

This update makes the mobile Playground more practical for learning and coding on a phone.

## Testing

* Checked the Playground lesson view on mobile
* Checked that Lesson, Code, Output, Map, Progress, and Modules are reachable
* Checked that the editor remains usable on mobile
* Checked that output and tests remain accessible
* Confirmed desktop UI was not intentionally changed

