### PR TITLE
/api/health endpoint for healthchecks

### DIFF
--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -8,4 +8,6 @@ Lessons are located in `content/lessons/`. If you'd like to submit a new lesson 
 
 ### Healthchecks
 
-For deployments with docker, healthcheks must be run against `/${locale}` eg `/sw/` not `/` which will return a redirect. Redirects are 'bad' as far as healthchecks are concerned. 
+For deployments with docker, healthchecks must be run against `/api/health`, which returns a static `200 ok` without touching the database or redirecting.
+
+Do **not** point healthchecks at `/` (returns a redirect, which is 'bad' for healthchecks) or at a locale path like `/en/` or `/sw/`. Those routes render the layout, which queries the database on every request — a monitor pinging them keeps the Neon serverless compute permanently awake (it never autosuspends), burning compute hours even with zero real users. 

--- a/apps/playground/app/api/health/route.ts
+++ b/apps/playground/app/api/health/route.ts
@@ -1,0 +1,5 @@
+export const dynamic = "force-static";
+
+export function GET() {
+	return new Response("ok", { status: 200 });
+}


### PR DESCRIPTION
Our uptime monitoring tool was contributing significantly to our monthly db compute usage on Neon. This PR introduces a simple health check api endpoint that does not hit the db which should save us a lot of CU-hrs